### PR TITLE
Fix the known remaining white space issues.

### DIFF
--- a/src/main/java/org/openrewrite/cobol/CobolIsoVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/CobolIsoVisitor.java
@@ -61,8 +61,18 @@ public class CobolIsoVisitor<P> extends CobolVisitor<P> {
     }
 
     @Override
+    public Cobol.AddCorresponding visitAddCorresponding(Cobol.AddCorresponding addCorresponding, P p) {
+        return (Cobol.AddCorresponding) super.visitAddCorresponding(addCorresponding, p);
+    }
+
+    @Override
     public Cobol.AddTo visitAddTo(Cobol.AddTo addTo, P p) {
         return (Cobol.AddTo) super.visitAddTo(addTo, p);
+    }
+
+    @Override
+    public Cobol.AddToGiving visitAddToGiving(Cobol.AddToGiving addToGiving, P p) {
+        return (Cobol.AddToGiving) super.visitAddToGiving(addToGiving, p);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/cobol/CobolIsoVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/CobolIsoVisitor.java
@@ -2160,6 +2160,11 @@ public class CobolIsoVisitor<P> extends CobolVisitor<P> {
     }
 
     @Override
+    public Cobol.Words visitWords(Cobol.Words words, P p) {
+        return (Cobol.Words) super.visitWords(words, p);
+    }
+
+    @Override
     public Cobol.WorkingStorageSection visitWorkingStorageSection(Cobol.WorkingStorageSection workingStorageSection, P p) {
         return (Cobol.WorkingStorageSection) super.visitWorkingStorageSection(workingStorageSection, p);
     }

--- a/src/main/java/org/openrewrite/cobol/CobolVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/CobolVisitor.java
@@ -94,13 +94,36 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         return a;
     }
 
+    public Cobol visitAddCorresponding(Cobol.AddCorresponding addCorresponding, P p) {
+        Cobol.AddCorresponding a = addCorresponding;
+        a = a.withPrefix(visitSpace(a.getPrefix(), p));
+        a = a.withMarkers(visitMarkers(a.getMarkers(), p));
+        a = a.withCorresponding((Cobol.CobolWord) visit(a.getCorresponding(), p));
+        a = a.withIdentifier((Identifier) visit(a.getIdentifier(), p));
+        a = a.withTo((Cobol.CobolWord) visit(a.getTo(), p));
+        a = a.withRoundable((Cobol.Roundable) visit(a.getRoundable(), p));
+        return a;
+    }
+
     public Cobol visitAddTo(Cobol.AddTo addTo, P p) {
         Cobol.AddTo a = addTo;
         a = a.withPrefix(visitSpace(a.getPrefix(), p));
         a = a.withMarkers(visitMarkers(a.getMarkers(), p));
         a = a.withFrom(ListUtils.map(a.getFrom(), t -> (Name) visit(t, p)));
-        a = a.getPadding().withTo(visitContainer(a.getPadding().getTo(), p));
-        a = a.getPadding().withGiving(visitContainer(a.getPadding().getGiving(), p));
+        a = a.withTo((Cobol.CobolWord) visit(a.getTo(), p));
+        a = a.withRoundables(ListUtils.map(a.getRoundables(), t -> (Name) visit(t, p)));
+        return a;
+    }
+
+    public Cobol visitAddToGiving(Cobol.AddToGiving addToGiving, P p) {
+        Cobol.AddToGiving a = addToGiving;
+        a = a.withPrefix(visitSpace(a.getPrefix(), p));
+        a = a.withMarkers(visitMarkers(a.getMarkers(), p));
+        a = a.withFrom(ListUtils.map(a.getFrom(), t -> (Name) visit(t, p)));
+        a = a.withTo((Cobol.CobolWord) visit(a.getTo(), p));
+        a = a.withNames(ListUtils.map(a.getNames(), t -> (Name) visit(t, p)));
+        a = a.withGiving((Cobol.CobolWord) visit(a.getGiving(), p));
+        a = a.withRoundables(ListUtils.map(a.getRoundables(), t -> (Name) visit(t, p)));
         return a;
     }
 
@@ -395,7 +418,9 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.CollatingSequenceClause c = collatingSequenceClause;
         c = c.withPrefix(visitSpace(c.getPrefix(), p));
         c = c.withMarkers(visitMarkers(c.getMarkers(), p));
-        c = c.getPadding().withAlphabetName(visitContainer(c.getPadding().getAlphabetName(), p));
+        c = c.withWords(ListUtils.map(c.getWords(), it -> (Cobol.CobolWord) visit(it, p)));
+        c = c.withIs((Cobol.CobolWord) visit(c.getIs(), p));
+        c = c.withAlphabetName(ListUtils.map(c.getAlphabetName(), it -> (Cobol.CobolWord) visit(it, p)));
         c = c.withAlphanumeric((Cobol.CollatingSequenceAlphabet) visit(c.getAlphanumeric(), p));
         c = c.withNational((Cobol.CollatingSequenceAlphabet) visit(c.getNational(), p));
         return c;
@@ -532,9 +557,7 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         c = c.withPrefix(visitSpace(c.getPrefix(), p));
         c = c.withMarkers(visitMarkers(c.getMarkers(), p));
         c = c.withLiteral((Literal) visit(c.getLiteral(), p));
-        if (c.getPadding().getPictureSymbol() != null) {
-            c = c.getPadding().withPictureSymbol(visitLeftPadded(c.getPadding().getPictureSymbol(), p));
-        }
+        c = c.withPictureSymbols(ListUtils.map(c.getPictureSymbols(), it -> (Cobol.CobolWord) visit(it, p)));
         c = c.withPictureSymbolLiteral((Literal) visit(c.getPictureSymbolLiteral(), p));
         return c;
     }
@@ -1705,7 +1728,8 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         m = m.withPrefix(visitSpace(m.getPrefix(), p));
         m = m.withMarkers(visitMarkers(m.getMarkers(), p));
         m = m.withMoveCorrespondingToSendingArea((Identifier) visit(m.getMoveCorrespondingToSendingArea(), p));
-        m = m.getPadding().withTo(visitContainer(m.getPadding().getTo(), p));
+        m = m.withTo((Cobol.CobolWord) visit(m.getTo(), p));
+        m = m.withIdentifiers(ListUtils.map(m.getIdentifiers(), t -> (Identifier) visit(t, p)));
         return m;
     }
 
@@ -1775,7 +1799,9 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.MultiplyGiving m = multiplyGiving;
         m = m.withPrefix(visitSpace(m.getPrefix(), p));
         m = m.withMarkers(visitMarkers(m.getMarkers(), p));
-        m = m.getPadding().withResult(visitContainer(m.getPadding().getResult(), p));
+        m = m.withOperand((Name) visit(m.getOperand(), p));
+        m = m.withGiving((Cobol.CobolWord) visit(m.getGiving(), p));
+        m = m.withResult(ListUtils.map(m.getResult(), it -> (Cobol.Roundable) visit(it, p)));
         return m;
     }
 
@@ -2180,7 +2206,8 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.Purge pp = purge;
         pp = pp.withPrefix(visitSpace(pp.getPrefix(), p));
         pp = pp.withMarkers(visitMarkers(pp.getMarkers(), p));
-        pp = pp.getPadding().withNames(visitContainer(pp.getPadding().getNames(), p));
+        pp = pp.withPurge((Cobol.CobolWord) visit(pp.getPurge(), p));
+        pp = pp.withNames(ListUtils.map(pp.getNames(), t -> (Name) visit(t, p)));
         return pp;
     }
 
@@ -3194,8 +3221,9 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.SetTo s = setTo;
         s = s.withPrefix(visitSpace(s.getPrefix(), p));
         s = s.withMarkers(visitMarkers(s.getMarkers(), p));
-        s = s.withTo(ListUtils.map(s.getTo(), t -> (Identifier) visit(t, p)));
-        s = s.getPadding().withValues(visitContainer(s.getPadding().getValues(), p));
+        s = s.withIdentifiers(ListUtils.map(s.getIdentifiers(), t -> (Identifier) visit(t, p)));
+        s = s.withTo((Cobol.CobolWord) visit(s.getTo(), p));
+        s = s.withValues(ListUtils.map(s.getValues(), t -> (Name) visit(t, p)));
         return s;
     }
 

--- a/src/main/java/org/openrewrite/cobol/CobolVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/CobolVisitor.java
@@ -123,7 +123,7 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         a = a.withTo((Cobol.CobolWord) visit(a.getTo(), p));
         a = a.withNames(ListUtils.map(a.getNames(), t -> (Name) visit(t, p)));
         a = a.withGiving((Cobol.CobolWord) visit(a.getGiving(), p));
-        a = a.withRoundables(ListUtils.map(a.getRoundables(), t -> (Name) visit(t, p)));
+        a = a.withRoundables(ListUtils.map(a.getRoundables(), t -> (Cobol.Roundable) visit(t, p)));
         return a;
     }
 
@@ -184,7 +184,8 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.AlteredGoTo a = alteredGoTo;
         a = a.withPrefix(visitSpace(a.getPrefix(), p));
         a = a.withMarkers(visitMarkers(a.getMarkers(), p));
-        a = a.getPadding().withDot(visitLeftPadded(a.getPadding().getDot(), p));
+        a = a.withWords(ListUtils.map(a.getWords(), it -> (Cobol.CobolWord) visit(it, p)));
+        a = a.withDot((Cobol.CobolWord) visit(a.getDot(), p));
         return a;
     }
 
@@ -489,11 +490,11 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
     }
 
     public Cobol visitCompilationUnit(Cobol.CompilationUnit compilationUnit, P p) {
-        Cobol.CompilationUnit d = compilationUnit;
-        d = d.withPrefix(visitSpace(d.getPrefix(), p));
-        d = d.withMarkers(visitMarkers(d.getMarkers(), p));
-        d = d.getPadding().withProgramUnits(ListUtils.map(d.getPadding().getProgramUnits(), it -> visitRightPadded(it, p)));
-        return d;
+        Cobol.CompilationUnit c = compilationUnit;
+        c = c.withPrefix(visitSpace(c.getPrefix(), p));
+        c = c.withMarkers(visitMarkers(c.getMarkers(), p));
+        c = c.withProgramUnits(ListUtils.map(c.getProgramUnits(), it -> (Cobol.ProgramUnit) visit(it, p)));
+        return c;
     }
 
     public Cobol visitCompute(Cobol.Compute compute, P p) {
@@ -655,9 +656,12 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.DataOccursClause d = dataOccursClause;
         d = d.withPrefix(visitSpace(d.getPrefix(), p));
         d = d.withMarkers(visitMarkers(d.getMarkers(), p));
+        d = d.withOccurs((Cobol.CobolWord) visit(d.getOccurs(), p));
+        d = d.withName((Name) visit(d.getName(), p));
         d = d.withDataOccursTo((Cobol.DataOccursTo) visit(d.getDataOccursTo(), p));
+        d = d.withTimes((Cobol.CobolWord) visit(d.getTimes(), p));
         d = d.withDataOccursDepending((Cobol.DataOccursDepending) visit(d.getDataOccursDepending(), p));
-        d = d.getPadding().withSortIndexed(visitContainer(d.getPadding().getSortIndexed(), p));
+        d = d.withSortIndexed(ListUtils.map(d.getSortIndexed(), t -> visit(t, p)));
         return d;
     }
 
@@ -948,6 +952,9 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.EndProgram e = endProgram;
         e = e.withPrefix(visitSpace(e.getPrefix(), p));
         e = e.withMarkers(visitMarkers(e.getMarkers(), p));
+        e = e.withWords(ListUtils.map(e.getWords(), it -> (Cobol.CobolWord) visit(it, p)));
+        e = e.withProgramName((Name) visit(e.getProgramName(), p));
+        e = e.withDot((Cobol.CobolWord) visit(e.getDot(), p));
         return e;
     }
 
@@ -1323,7 +1330,8 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.InspectAllLeadings i = inspectAllLeadings;
         i = i.withPrefix(visitSpace(i.getPrefix(), p));
         i = i.withMarkers(visitMarkers(i.getMarkers(), p));
-        i = i.getPadding().withLeadings(visitContainer(i.getPadding().getLeadings(), p));
+        i = i.withWord((Cobol.CobolWord) visit(i.getWord(), p));
+        i = i.withLeadings(ListUtils.map(i.getLeadings(), t -> (Cobol.InspectAllLeading) visit(t, p)));
         return i;
     }
 
@@ -1365,7 +1373,9 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.InspectFor i = inspectFor;
         i = i.withPrefix(visitSpace(i.getPrefix(), p));
         i = i.withMarkers(visitMarkers(i.getMarkers(), p));
-        i = i.getPadding().withInspects(visitContainer(i.getPadding().getInspects(), p));
+        i = i.withIdentifier((Identifier) visit(i.getIdentifier(), p));
+        i = i.withWord((Cobol.CobolWord) visit(i.getWord(), p));
+        i = i.withInspects(ListUtils.map(i.getInspects(), t -> visit(t, p)));
         return i;
     }
 
@@ -1400,7 +1410,8 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.InspectReplacingPhrase i = inspectReplacingPhrase;
         i = i.withPrefix(visitSpace(i.getPrefix(), p));
         i = i.withMarkers(visitMarkers(i.getMarkers(), p));
-        i = i.getPadding().withInspections(visitContainer(i.getPadding().getInspections(), p));
+        i = i.withWord((Cobol.CobolWord) visit(i.getWord(), p));
+        i = i.withInspections(ListUtils.map(i.getInspections(), t -> visit(t, p)));
         return i;
     }
 
@@ -1433,9 +1444,12 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.IoControlParagraph i = ioControlParagraph;
         i = i.withPrefix(visitSpace(i.getPrefix(), p));
         i = i.withMarkers(visitMarkers(i.getMarkers(), p));
+        i = i.withIOControl((Cobol.CobolWord) visit(i.getIOControl(), p));
         i = i.withDot((Cobol.CobolWord) visit(i.getDot(), p));
         i = i.withFileName((Cobol.CobolWord) visit(i.getFileName(), p));
-        i = i.getPadding().withClauses(visitContainer(i.getPadding().getClauses(), p));
+        i = i.withFileNameDot((Cobol.CobolWord) visit(i.getFileNameDot(), p));
+        i = i.withClauses(ListUtils.map(i.getClauses(), it -> visit(it, p)));
+        i = i.withDot2((Cobol.CobolWord) visit(i.getDot2(), p));
         return i;
     }
 
@@ -1499,10 +1513,12 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.LibraryDescriptionEntryFormat2 l = libraryDescriptionEntryFormat2;
         l = l.withPrefix(visitSpace(l.getPrefix(), p));
         l = l.withMarkers(visitMarkers(l.getMarkers(), p));
+        l = l.withLb((Cobol.CobolWord) visit(l.getLb(), p));
         l = l.withLibraryName((Cobol.CobolWord) visit(l.getLibraryName(), p));
+        l = l.withExport((Cobol.CobolWord) visit(l.getExport(), p));
         l = l.withLibraryIsGlobalClause((Cobol.LibraryIsGlobalClause) visit(l.getLibraryIsGlobalClause(), p));
         l = l.withLibraryIsCommonClause((Cobol.LibraryIsCommonClause) visit(l.getLibraryIsCommonClause(), p));
-        l = l.getPadding().withClauseFormats(visitContainer(l.getPadding().getClauseFormats(), p));
+        l = l.withClauseFormats(ListUtils.map(l.getClauseFormats(), it -> visit(it, p)));
         return l;
     }
 
@@ -1850,7 +1866,8 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.Open o = open;
         o = o.withPrefix(visitSpace(o.getPrefix(), p));
         o = o.withMarkers(visitMarkers(o.getMarkers(), p));
-        o = o.getPadding().withOpen(visitContainer(o.getPadding().getOpen(), p));
+        o = o.withWords((Cobol.CobolWord) visit(o.getWords(), p));
+        o = o.withOpen(ListUtils.map(o.getOpen(), it -> visit(it, p)));
         return o;
     }
 
@@ -2196,9 +2213,7 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         pp = pp.withDataDivision((Cobol.DataDivision) visit(pp.getDataDivision(), p));
         pp = pp.withProcedureDivision((Cobol.ProcedureDivision) visit(pp.getProcedureDivision(), p));
         pp = pp.withProgramUnits(ListUtils.map(pp.getProgramUnits(), t -> (Cobol.ProgramUnit) visit(t, p)));
-        if (pp.getPadding().getEndProgram() != null) {
-            pp = pp.getPadding().withEndProgram(visitRightPadded(pp.getPadding().getEndProgram(), p));
-        }
+        pp = pp.withEndProgram((Cobol.EndProgram) visit(pp.getEndProgram(), p));
         return pp;
     }
 
@@ -2327,8 +2342,9 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         r = r.withPrefix(visitSpace(r.getPrefix(), p));
         r = r.withMarkers(visitMarkers(r.getMarkers(), p));
         r = r.withDataName((Cobol.CobolWord) visit(r.getDataName(), p));
+        r = r.withFrom((Cobol.CobolWord) visit(r.getFrom(), p));
         r = r.withReceiveFrom((Cobol.ReceiveFrom) visit(r.getReceiveFrom(), p));
-        r = r.getPadding().withBeforeWithThreadSizeStatus(visitContainer(r.getPadding().getBeforeWithThreadSizeStatus(), p));
+        r = r.withBeforeWithThreadSizeStatus(ListUtils.map(r.getBeforeWithThreadSizeStatus(), it -> visit(it, p)));
         return r;
     }
 
@@ -2597,7 +2613,7 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         r = r.withMarkers(visitMarkers(r.getMarkers(), p));
         r = r.withIntegerLiteral((Cobol.CobolWord) visit(r.getIntegerLiteral(), p));
         r = r.withDataName((Cobol.CobolWord) visit(r.getDataName(), p));
-        r = r.getPadding().withClauses(visitContainer(r.getPadding().getClauses(), p));
+        r = r.withClauses(ListUtils.map(r.getClauses(), it -> visit(it, p)));
         r = r.withDot((Cobol.CobolWord) visit(r.getDot(), p));
         return r;
     }
@@ -3734,6 +3750,14 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         return v;
     }
 
+    public Cobol visitWords(Cobol.Words words, P p) {
+        Cobol.Words w = words;
+        w = w.withPrefix(visitSpace(w.getPrefix(), p));
+        w = w.withMarkers(visitMarkers(w.getMarkers(), p));
+        w = w.withWords(ListUtils.map(w.getWords(), it -> (Cobol.CobolWord) visit(it, p)));
+        return w;
+    }
+
     public Cobol visitWorkingStorageSection(Cobol.WorkingStorageSection workingStorageSection, P p) {
         Cobol.WorkingStorageSection w = workingStorageSection;
         w = w.withPrefix(visitSpace(w.getPrefix(), p));
@@ -3793,78 +3817,4 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         w = w.withMarkers(visitMarkers(w.getMarkers(), p));
         return w;
     }
-
-
-    public <P2 extends Cobol> CobolContainer<P2> visitContainer(@Nullable CobolContainer<P2> container, P p) {
-        if (container == null) {
-            //noinspection ConstantConditions
-            return null;
-        }
-
-        setCursor(new Cursor(getCursor(), container));
-
-        Space before = visitSpace(container.getBefore(), p);
-        CobolLeftPadded<String> preposition = visitLeftPadded(container.getPreposition(), p);
-        List<CobolRightPadded<P2>> ps = ListUtils.map(container.getPadding().getElements(), t -> visitRightPadded(t, p));
-        Markers markers = visitMarkers(container.getMarkers(), p);
-
-        setCursor(getCursor().getParent());
-
-        return (ps == container.getPadding().getElements() && before == container.getBefore() && preposition == container.getPreposition() &&
-                markers == container.getMarkers()) ?
-                container :
-                CobolContainer.build(before, preposition, ps, markers);
-    }
-
-
-    public <T> CobolLeftPadded<T> visitLeftPadded(@Nullable CobolLeftPadded<T> left, P p) {
-        if (left == null) {
-            //noinspection ConstantConditions
-            return null;
-        }
-
-        setCursor(new Cursor(getCursor(), left));
-
-        Space before = visitSpace(left.getBefore(), p);
-        T t = left.getElement();
-
-        if (t instanceof Cobol) {
-            //noinspection unchecked
-            t = visitAndCast((Cobol) left.getElement(), p);
-        }
-
-        setCursor(getCursor().getParent());
-        if (t == null) {
-            //noinspection ConstantConditions
-            return null;
-        }
-
-        return (before == left.getBefore() && t == left.getElement()) ? left : new CobolLeftPadded<>(before, t, left.getMarkers());
-    }
-
-
-    @SuppressWarnings("ConstantConditions")
-    public <T> CobolRightPadded<T> visitRightPadded(@Nullable CobolRightPadded<T> right, P p) {
-        if (right == null) {
-            //noinspection ConstantConditions
-            return null;
-        }
-
-        setCursor(new Cursor(getCursor(), right));
-
-        T t = right.getElement();
-        if (t instanceof Cobol) {
-            //noinspection unchecked
-            t = (T) visit((Cobol) right.getElement(), p);
-        }
-
-        setCursor(getCursor().getParent());
-        if (t == null) {
-            //noinspection ConstantConditions
-            return null;
-        }
-        Space after = visitSpace(right.getAfter(), p);
-        return (after == right.getAfter() && t == right.getElement()) ? right : new CobolRightPadded<>(t, after, right.getMarkers());
-    }
-
 }

--- a/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -168,9 +168,9 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         init();
 
         Space prefix = whitespace();
-        List<CobolRightPadded<Cobol.ProgramUnit>> programUnits = new ArrayList<>(ctx.programUnit().size());
+        List<Cobol.ProgramUnit> programUnits = new ArrayList<>(ctx.programUnit().size());
         for (CobolParser.ProgramUnitContext pu : ctx.programUnit()) {
-            programUnits.add(CobolRightPadded.build(visitProgramUnit(pu)));
+            programUnits.add(visitProgramUnit(pu));
         }
         return new Cobol.CompilationUnit(
                 randomId(),
@@ -406,6 +406,17 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 Markers.EMPTY,
                 (Cobol.CobolWord) visit(ctx.ALTER()),
                 convertAll(ctx.alterProceedTo())
+        );
+    }
+
+    @Override
+    public Object visitAlteredGoTo(CobolParser.AlteredGoToContext ctx) {
+        return new Cobol.AlteredGoTo(
+                randomId(),
+                whitespace(),
+                Markers.EMPTY,
+                wordsList(ctx.GO(), ctx.TO()),
+                (Cobol.CobolWord) visit(ctx.DOT_FS())
         );
     }
 
@@ -1206,7 +1217,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 visitNullable(ctx.dataOccursTo()),
                 visitNullable(ctx.TIMES()),
                 visitNullable(ctx.dataOccursDepending()),
-                convertAllContainer(ctx.dataOccursSort(), ctx.dataOccursIndexed())
+                convertAll(ctx.dataOccursSort(), ctx.dataOccursIndexed())
         );
     }
 
@@ -1677,7 +1688,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 whitespace(),
                 Markers.EMPTY,
                 wordsList(ctx.END(), ctx.PROGRAM()),
-                (Name) visit(ctx.programName())
+                (Name) visit(ctx.programName()),
+                (Cobol.CobolWord) visit(ctx.DOT_FS())
         );
     }
 
@@ -2189,7 +2201,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
 
     @Override
     public Object visitInspectAllLeadings(CobolParser.InspectAllLeadingsContext ctx) {
-        return new Cobol.InspectAllLeading(
+        return new Cobol.InspectAllLeadings(
                 randomId(),
                 whitespace(),
                 Markers.EMPTY,
@@ -2252,7 +2264,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 Markers.EMPTY,
                 (Identifier) visit(ctx.identifier()),
                 (Cobol.CobolWord) visit(ctx.FOR()),
-                convertAllContainer(ctx.inspectCharacters(), ctx.inspectAllLeadings())
+                convertAll(ctx.inspectCharacters(), ctx.inspectAllLeadings())
         );
     }
 
@@ -2298,7 +2310,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 whitespace(),
                 Markers.EMPTY,
                 (Cobol.CobolWord) visit(ctx.REPLACING()),
-                convertAllContainer(ctx.inspectReplacingCharacters(), ctx.inspectReplacingAllLeadings())
+                convertAll(ctx.inspectReplacingCharacters(), ctx.inspectReplacingAllLeadings())
         );
     }
 
@@ -2369,8 +2381,9 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 (Cobol.CobolWord) visit(ctx.I_O_CONTROL()),
                 (Cobol.CobolWord) visit(ctx.DOT_FS(0)),
                 visitNullable(ctx.fileName()),
-                ctx.fileName() == null ? null : (Cobol.CobolWord) visit(ctx.DOT_FS(1)),
-                convertAllContainer(ctx.ioControlClause()).withLastSpace(sourceBefore("."))
+                ctx.DOT_FS().size() < 2 ? null : (Cobol.CobolWord) visit(ctx.DOT_FS(1)),
+                convertAll(ctx.ioControlClause()),
+                ctx.DOT_FS().size() < 3 ? null : (Cobol.CobolWord) visit(ctx.DOT_FS(2))
         );
     }
 
@@ -2467,7 +2480,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 (Cobol.CobolWord) visit(ctx.IMPORT()),
                 visitNullable(ctx.libraryIsGlobalClause()),
                 visitNullable(ctx.libraryIsCommonClause()),
-                convertAllContainer(ctx.libraryAttributeClauseFormat2(), ctx.libraryEntryProcedureClauseFormat2())
+                convertAll(ctx.libraryAttributeClauseFormat2(), ctx.libraryEntryProcedureClauseFormat2())
         );
     }
 
@@ -3121,7 +3134,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 whitespace(),
                 Markers.EMPTY,
                 (Cobol.CobolWord) visit(ctx.OPEN()),
-                convertAllContainer(ctx.openInputStatement(), ctx.openOutputStatement(), ctx.openIOStatement(),
+                convertAll(ctx.openInputStatement(), ctx.openOutputStatement(), ctx.openIOStatement(),
                         ctx.openExtendStatement())
         );
     }
@@ -3584,13 +3597,12 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 randomId(),
                 whitespace(),
                 Markers.EMPTY,
-                (Cobol.IdentificationDivision) visitIdentificationDivision(ctx.identificationDivision()),
+                (Cobol.IdentificationDivision) visit(ctx.identificationDivision()),
                 visitNullable(ctx.environmentDivision()),
                 visitNullable(ctx.dataDivision()),
                 visitNullable(ctx.procedureDivision()),
                 convertAll(ctx.programUnit()),
-                ctx.endProgramStatement() == null ? null : padRight(visitEndProgramStatement(ctx.endProgramStatement()),
-                        sourceBefore("."))
+                visitNullable(ctx.endProgramStatement())
         );
     }
 
@@ -3753,7 +3765,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 (Cobol.CobolWord) visit(ctx.dataName()),
                 (Cobol.CobolWord) visit(ctx.FROM()),
                 (Cobol.ReceiveFrom) visit(ctx.receiveFrom()),
-                convertAllContainer(ctx.receiveBefore(), ctx.receiveWith(), ctx.receiveThread(), ctx.receiveSize(), ctx.receiveStatus())
+                convertAll(ctx.receiveBefore(), ctx.receiveWith(), ctx.receiveThread(), ctx.receiveSize(), ctx.receiveStatus())
         );
     }
 
@@ -3830,9 +3842,13 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
     }
 
     @Override
-    public Cobol.CobolWord visitReceiveWith(CobolParser.ReceiveWithContext ctx) {
-        // TODO: FIX ME
-        return words(ctx.WITH(), ctx.NO(), ctx.WAIT());
+    public Cobol.Words visitReceiveWith(CobolParser.ReceiveWithContext ctx) {
+        return new Cobol.Words(
+                randomId(),
+                whitespace(),
+                Markers.EMPTY,
+                wordsList(ctx.WITH(), ctx.NO(), ctx.WAIT())
+        );
     }
 
     @Override
@@ -4210,7 +4226,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 Markers.EMPTY,
                 (Cobol.CobolWord) visit(ctx.integerLiteral()),
                 visitNullable(ctx.dataName()),
-                convertAllContainer(ctx.reportGroupPictureClause(),
+                convertAll(ctx.reportGroupPictureClause(),
                         ctx.reportGroupUsageClause(),
                         ctx.reportGroupSignClause(),
                         ctx.reportGroupJustifiedClause(),
@@ -6075,37 +6091,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         return words;
     }
 
-    private @Nullable Cobol.CobolWord words(TerminalNode... wordNodes) {
-        Space prefix = null;
-        StringBuilder words = new StringBuilder();
-        Map<Integer, Markers> markersMap = new HashMap<>();
-        for (TerminalNode wordNode : wordNodes) {
-            if (wordNode != null) {
-                if (prefix == null) {
-                    prefix = whitespace();
-                }
-                Cobol.CobolWord cw = (Cobol.CobolWord) visit(wordNode);
-                Markers current = cw.getMarkers();
-                if (current != Markers.EMPTY) {
-                    markersMap.put(words.length(), current);
-                }
-                words.append(cw.getPrefix().getWhitespace());
-                words.append(cw.getWord());
-            }
-        }
-
-        if (words.toString().isEmpty()) {
-            return null;
-        }
-
-        return new Cobol.CobolWord(
-                randomId(),
-                prefix,
-                markersMap.isEmpty() ? Markers.EMPTY : Markers.build(singletonList(new Continuation(randomId(), markersMap))),
-                words.toString()
-        );
-    }
-
     private <C, T extends ParseTree> List<C> convertAll(List<T> trees, Function<T, C> convert) {
         List<C> converted = new ArrayList<>(trees.size());
         for (T tree : trees) {
@@ -6126,34 +6111,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
     private <C extends Cobol, T extends ParseTree> List<C> convertAll(List<T> trees) {
         //noinspection unchecked
         return convertAll(trees, t -> (C) visit(t));
-    }
-
-
-    private <C extends Cobol, T extends ParseTree> CobolContainer<C> convertAllContainer(@Nullable CobolLeftPadded<String> preposition, List<T> trees) {
-        return this.<C, T>convertAllContainer(trees, () -> Space.EMPTY).withPreposition(preposition);
-    }
-
-    private <C extends Cobol, T extends ParseTree> CobolContainer<C> convertAllContainer(Space before, List<T> trees) {
-        return this.<C, T>convertAllContainer(trees, () -> Space.EMPTY).withBefore(before);
-    }
-
-    private <C extends Cobol, T extends ParseTree> CobolContainer<C> convertAllContainer(List<T> trees) {
-        return convertAllContainer(trees, () -> Space.EMPTY);
-    }
-
-    @SafeVarargs
-    private final CobolContainer<Cobol> convertAllContainer(List<? extends ParserRuleContext>... trees) {
-        return convertAllContainer(Arrays.stream(trees)
-                        .filter(Objects::nonNull)
-                        .flatMap(Collection::stream)
-                        .sorted(Comparator.comparingInt(it -> it.start.getStartIndex()))
-                        .collect(Collectors.toList()),
-                () -> Space.EMPTY);
-    }
-
-    private <C extends Cobol, T extends ParseTree> CobolContainer<C> convertAllContainer(List<T> trees, Supplier<Space> sourceBefore) {
-        //noinspection unchecked
-        return CobolContainer.build(convertAll(trees, t -> padRight((C) visit(t), sourceBefore.get())));
     }
 
     @SafeVarargs
@@ -6221,46 +6178,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                     return Stream.of(cobol);
                 })
                 .collect(Collectors.toList());
-    }
-
-    private <T> CobolRightPadded<T> padRight(T tree, Space right) {
-        return new CobolRightPadded<>(tree, right, Markers.EMPTY);
-    }
-
-    // TODO: fix this may skip source code.
-    private int positionOfNext(String untilDelim, @Nullable Character stop) {
-        int delimIndex = cursor;
-        for (; delimIndex < source.length() - untilDelim.length() + 1; delimIndex++) {
-            if (stop != null && source.charAt(delimIndex) == stop)
-                return -1; // reached stop word before finding the delimiter
-
-            if (source.startsWith(untilDelim, delimIndex)) {
-                break; // found it!
-            }
-        }
-
-        return delimIndex > source.length() - untilDelim.length() ? -1 : delimIndex;
-    }
-
-    private Space sourceBefore(String untilDelim) {
-        return sourceBefore(untilDelim, null);
-    }
-
-    /**
-     * @return Source from <code>cursor</code> to next occurrence of <code>untilDelim</code>,
-     * and if not found in the remaining source, the empty String. If <code>stop</code> is reached before
-     * <code>untilDelim</code> return the empty String.
-     */
-    private Space sourceBefore(String untilDelim, @Nullable Character stop) {
-        // TODO: fix me. skips source code.
-        int delimIndex = positionOfNext(untilDelim, stop);
-        if (delimIndex < 0) {
-            return Space.EMPTY; // unable to find this delimiter
-        }
-
-        String prefix = source.substring(cursor, delimIndex);
-        cursor += prefix.length() + untilDelim.length(); // advance past the delimiter
-        return format(prefix);
     }
 
     // TODO: check. Methods should not assume text / cursor is incremented.

--- a/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -272,6 +272,19 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
     }
 
     @Override
+    public Object visitAddCorrespondingStatement(CobolParser.AddCorrespondingStatementContext ctx) {
+        return new Cobol.AddCorresponding(
+                randomId(),
+                whitespace(),
+                Markers.EMPTY,
+                visit(ctx.CORRESPONDING(), ctx.CORR()),
+                (Identifier) visit(ctx.identifier()),
+                (Cobol.CobolWord) visit(ctx.TO()),
+                (Cobol.Roundable) visit(ctx.addTo())
+        );
+    }
+
+    @Override
     public Cobol.Add visitAddStatement(CobolParser.AddStatementContext ctx) {
         return new Cobol.Add(
                 randomId(),
@@ -286,14 +299,16 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
     }
 
     @Override
-    public Cobol.AddTo visitAddToGivingStatement(CobolParser.AddToGivingStatementContext ctx) {
-        return new Cobol.AddTo(
+    public Cobol.AddToGiving visitAddToGivingStatement(CobolParser.AddToGivingStatementContext ctx) {
+        return new Cobol.AddToGiving(
                 randomId(),
                 Space.EMPTY,
                 Markers.EMPTY,
                 convertAll(ctx.addFrom()),
-                convertAllContainer(padLeft(ctx.TO()), ctx.addToGiving()),
-                convertAllContainer(padLeft(ctx.GIVING()), ctx.addGiving())
+                visitNullable(ctx.TO()),
+                convertAll(ctx.addToGiving()),
+                (Cobol.CobolWord) visit(ctx.GIVING()),
+                convertAll(ctx.addGiving())
         );
     }
 
@@ -304,8 +319,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 Space.EMPTY,
                 Markers.EMPTY,
                 convertAll(ctx.addFrom()),
-                convertAllContainer(padLeft(ctx.TO()), ctx.addTo()),
-                null
+                visitNullable(ctx.TO()),
+                convertAll(ctx.addTo())
         );
     }
 
@@ -806,7 +821,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 whitespace(),
                 Markers.EMPTY,
                 wordsList(ctx.PROGRAM(), ctx.COLLATING(), ctx.SEQUENCE()),
-                convertAllContainer(padLeft(ctx.IS()), ctx.alphabetName()),
+                (Cobol.CobolWord) visit(ctx.IS()),
+                convertAll(ctx.alphabetName()),
                 visitNullable(ctx.collatingSequenceClauseAlphanumeric()),
                 visitNullable(ctx.collatingSequenceClauseNational())
         );
@@ -1013,7 +1029,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 Markers.EMPTY,
                 wordsList(ctx.CURRENCY(), ctx.SIGN(), ctx.IS()),
                 (Literal) visit(ctx.literal(0)),
-                ctx.literal().size() > 1 ? padLeft(whitespace(), words(ctx.WITH(), ctx.PICTURE(), ctx.SYMBOL())) : null,
+                wordsList(ctx.WITH(), ctx.PICTURE(), ctx.SYMBOL()),
                 ctx.literal().size() > 1 ? (Literal) visit(ctx.literal(1)) : null
         );
     }
@@ -1673,7 +1689,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 Markers.EMPTY,
                 (Cobol.CobolWord) visit(ctx.ENTRY()),
                 (Literal) visit(ctx.literal()),
-                convertAllContainer(padLeft(ctx.USING()), ctx.identifier())
+                (Cobol.CobolWord) visit(ctx.USING()),
+                convertAll(ctx.identifier())
         );
     }
 
@@ -2792,7 +2809,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 Markers.EMPTY,
                 visit(ctx.CORRESPONDING(), ctx.CORR()),
                 (Identifier) visit(ctx.moveCorrespondingToSendingArea()),
-                convertAllContainer(padLeft(ctx.TO()), ctx.identifier())
+                (Cobol.CobolWord) visit(ctx.TO()),
+                convertAll(ctx.identifier())
         );
     }
 
@@ -2871,7 +2889,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 whitespace(),
                 Markers.EMPTY,
                 (Name) visit(ctx.multiplyGivingOperand()),
-                convertAllContainer(padLeft(ctx.GIVING()), ctx.multiplyGivingResult())
+                (Cobol.CobolWord) visit(ctx.GIVING()),
+                convertAll(ctx.multiplyGivingResult())
         );
     }
 
@@ -3581,7 +3600,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 randomId(),
                 whitespace(),
                 Markers.EMPTY,
-                convertAllContainer(padLeft(ctx.PURGE()), ctx.cdName())
+                (Cobol.CobolWord) visit(ctx.PURGE()),
+                convertAll(ctx.cdName())
         );
     }
 
@@ -5167,7 +5187,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 whitespace(),
                 Markers.EMPTY,
                 convertAll(ctx.setTo()),
-                convertAllContainer(padLeft(ctx.TO()), ctx.setToValue())
+                (Cobol.CobolWord) visit(ctx.TO()),
+                convertAll(ctx.setToValue())
         );
     }
 
@@ -6200,19 +6221,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                     return Stream.of(cobol);
                 })
                 .collect(Collectors.toList());
-    }
-
-    private <T> CobolLeftPadded<T> padLeft(Space left, T tree) {
-        return new CobolLeftPadded<>(left, tree, Markers.EMPTY);
-    }
-
-    // TODO: fix me. The tree should be visited instead of using text.
-    private CobolLeftPadded<String> padLeft(@Nullable ParseTree pt) {
-        if (pt == null) {
-            //noinspection ConstantConditions
-            return null;
-        }
-        return padLeft(sourceBefore(pt.getText()), pt.getText());
     }
 
     private <T> CobolRightPadded<T> padRight(T tree, Space right) {

--- a/src/main/java/org/openrewrite/cobol/internal/CobolPrinter.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolPrinter.java
@@ -194,7 +194,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitSpace(alteredGoTo.getPrefix(), p);
         visitMarkers(alteredGoTo.getMarkers(), p);
         visit(alteredGoTo.getWords(), p);
-        visitLeftPadded("", alteredGoTo.getPadding().getDot(), p);
+        visit(alteredGoTo.getDot(), p);
         return alteredGoTo;
     }
 
@@ -718,7 +718,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visit(dataOccursClause.getDataOccursTo(), p);
         visit(dataOccursClause.getTimes(), p);
         visit(dataOccursClause.getDataOccursDepending(), p);
-        visitContainer("", dataOccursClause.getPadding().getSortIndexed(), "", "", p);
+        visit(dataOccursClause.getSortIndexed(), p);
         return dataOccursClause;
     }
 
@@ -1023,6 +1023,8 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitSpace(endProgram.getPrefix(), p);
         visitMarkers(endProgram.getMarkers(), p);
         visit(endProgram.getWords(), p);
+        visit(endProgram.getProgramName(), p);
+        visit(endProgram.getDot(), p);
         return endProgram;
     }
 
@@ -1395,7 +1397,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitSpace(inspectAllLeadings.getPrefix(), p);
         visitMarkers(inspectAllLeadings.getMarkers(), p);
         visit(inspectAllLeadings.getWord(), p);
-        visitContainer("", inspectAllLeadings.getPadding().getLeadings(), "", "", p);
+        visit(inspectAllLeadings.getLeadings(), p);
         return inspectAllLeadings;
     }
 
@@ -1438,7 +1440,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitMarkers(inspectFor.getMarkers(), p);
         visit(inspectFor.getIdentifier(), p);
         visit(inspectFor.getWord(), p);
-        visitContainer("", inspectFor.getPadding().getInspects(), "", "", p);
+        visit(inspectFor.getInspects(), p);
         return inspectFor;
     }
 
@@ -1472,7 +1474,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitSpace(inspectReplacingPhrase.getPrefix(), p);
         visitMarkers(inspectReplacingPhrase.getMarkers(), p);
         visit(inspectReplacingPhrase.getWord(), p);
-        visitContainer("", inspectReplacingPhrase.getPadding().getInspections(), "", "", p);
+        visit(inspectReplacingPhrase.getInspections(), p);
         return inspectReplacingPhrase;
     }
 
@@ -1508,7 +1510,8 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visit(ioControlParagraph.getDot(), p);
         visit(ioControlParagraph.getFileName(), p);
         visit(ioControlParagraph.getFileNameDot(), p);
-        visitContainer("", ioControlParagraph.getPadding().getClauses(), "", ".", p);
+        visit(ioControlParagraph.getClauses(), p);
+        visit(ioControlParagraph.getDot2(), p);
         return ioControlParagraph;
     }
 
@@ -1581,7 +1584,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visit(libraryDescriptionEntryFormat2.getExport(), p);
         visit(libraryDescriptionEntryFormat2.getLibraryIsGlobalClause(), p);
         visit(libraryDescriptionEntryFormat2.getLibraryIsCommonClause(), p);
-        visitContainer("", libraryDescriptionEntryFormat2.getPadding().getClauseFormats(), "", "", p);
+        visit(libraryDescriptionEntryFormat2.getClauseFormats(), p);
         return libraryDescriptionEntryFormat2;
     }
 
@@ -1933,7 +1936,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitSpace(open.getPrefix(), p);
         visitMarkers(open.getMarkers(), p);
         visit(open.getWords(), p);
-        visitContainer("", open.getPadding().getOpen(), "", "", p);
+        visit(open.getOpen(), p);
         return open;
     }
 
@@ -2293,7 +2296,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visit(programUnit.getDataDivision(), p);
         visit(programUnit.getProcedureDivision(), p);
         visit(programUnit.getProgramUnits(), p);
-        visitRightPadded(programUnit.getPadding().getEndProgram(), ".", p);
+        visit(programUnit.getEndProgram(), p);
         return programUnit;
     }
 
@@ -2422,7 +2425,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visit(receiveFromStatement.getDataName(), p);
         visit(receiveFromStatement.getFrom(), p);
         visit(receiveFromStatement.getReceiveFrom(), p);
-        visitContainer("", receiveFromStatement.getPadding().getBeforeWithThreadSizeStatus(), "", "", p);
+        visit(receiveFromStatement.getBeforeWithThreadSizeStatus(), p);
         return receiveFromStatement;
     }
 
@@ -2689,7 +2692,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitMarkers(reportGroupDescriptionEntryFormat3.getMarkers(), p);
         visit(reportGroupDescriptionEntryFormat3.getIntegerLiteral(), p);
         visit(reportGroupDescriptionEntryFormat3.getDataName(), p);
-        visitContainer("", reportGroupDescriptionEntryFormat3.getPadding().getClauses(), "", "", p);
+        visit(reportGroupDescriptionEntryFormat3.getClauses(), p);
         visit(reportGroupDescriptionEntryFormat3.getDot(), p);
         return reportGroupDescriptionEntryFormat3;
     }
@@ -3835,6 +3838,13 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         return valuedObjectComputerClause;
     }
 
+    public Cobol visitWords(Cobol.Words words, PrintOutputCapture<P> p) {
+        visitSpace(words.getPrefix(), p);
+        visitMarkers(words.getMarkers(), p);
+        visit(words.getWords(), p);
+        return words;
+    }
+
     public Cobol visitWorkingStorageSection(Cobol.WorkingStorageSection workingStorageSection, PrintOutputCapture<P> p) {
         visitSpace(workingStorageSection.getPrefix(), p);
         visitMarkers(workingStorageSection.getMarkers(), p);
@@ -3895,59 +3905,5 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visit(writeFromPhrase.getFrom(), p);
         visit(writeFromPhrase.getName(), p);
         return writeFromPhrase;
-    }
-
-
-    @SuppressWarnings("SameParameterValue")
-    protected void visitContainer(String before, @Nullable CobolContainer<? extends Cobol> container,
-                                  String suffixBetween, @Nullable String after, PrintOutputCapture<P> p) {
-        if (container == null) {
-            return;
-        }
-        visitSpace(container.getBefore(), p);
-        visitLeftPadded("", container.getPreposition(), p);
-        p.append(before);
-        visitRightPadded(container.getPadding().getElements(), suffixBetween, p);
-        p.append(after == null ? "" : after);
-    }
-
-    protected void visitLeftPadded(@Nullable String prefix, @Nullable CobolLeftPadded<?> leftPadded, PrintOutputCapture<P> p) {
-        if (leftPadded != null) {
-            visitSpace(leftPadded.getBefore(), p);
-            if (prefix != null) {
-                p.append(prefix);
-            }
-            if (leftPadded.getElement() instanceof Cobol) {
-                visit((Cobol) leftPadded.getElement(), p);
-            } else if (leftPadded.getElement() instanceof String) {
-                p.append(((String) leftPadded.getElement()));
-            }
-        }
-    }
-
-    protected void visitRightPadded(@Nullable CobolRightPadded<?> rightPadded, @Nullable String suffix, PrintOutputCapture<P> p) {
-        if (rightPadded != null) {
-            if (rightPadded.getElement() instanceof Cobol) {
-                visit((Cobol) rightPadded.getElement(), p);
-            } else if (rightPadded.getElement() instanceof String) {
-                p.append(((String) rightPadded.getElement()));
-            }
-            visitSpace(rightPadded.getAfter(), p);
-            if (suffix != null) {
-                p.append(suffix);
-            }
-        }
-    }
-
-    protected void visitRightPadded(List<? extends CobolRightPadded<? extends Cobol>> nodes, String suffixBetween, PrintOutputCapture<P> p) {
-        for (int i = 0; i < nodes.size(); i++) {
-            CobolRightPadded<? extends Cobol> node = nodes.get(i);
-            visit(node.getElement(), p);
-            visitSpace(node.getAfter(), p);
-            visitMarkers(node.getMarkers(), p);
-            if (i < nodes.size() - 1) {
-                p.append(suffixBetween);
-            }
-        }
     }
 }

--- a/src/main/java/org/openrewrite/cobol/internal/CobolPrinter.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolPrinter.java
@@ -103,13 +103,34 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         return add;
     }
 
+    public Cobol visitAddCorresponding(Cobol.AddCorresponding addCorresponding, PrintOutputCapture<P> p) {
+        visitSpace(addCorresponding.getPrefix(), p);
+        visitMarkers(addCorresponding.getMarkers(), p);
+        visit(addCorresponding.getCorresponding(), p);
+        visit(addCorresponding.getIdentifier(), p);
+        visit(addCorresponding.getTo(), p);
+        visit(addCorresponding.getRoundable(), p);
+        return addCorresponding;
+    }
+
     public Cobol visitAddTo(Cobol.AddTo addTo, PrintOutputCapture<P> p) {
         visitSpace(addTo.getPrefix(), p);
         visitMarkers(addTo.getMarkers(), p);
         visit(addTo.getFrom(), p);
-        visitContainer("", addTo.getPadding().getTo(), "", "", p);
-        visitContainer("", addTo.getPadding().getGiving(), "", "", p);
+        visit(addTo.getTo(), p);
+        visit(addTo.getRoundables(), p);
         return addTo;
+    }
+
+    public Cobol visitAddToGiving(Cobol.AddToGiving addToGiving, PrintOutputCapture<P> p) {
+        visitSpace(addToGiving.getPrefix(), p);
+        visitMarkers(addToGiving.getMarkers(), p);
+        visit(addToGiving.getFrom(), p);
+        visit(addToGiving.getTo(), p);
+        visit(addToGiving.getNames(), p);
+        visit(addToGiving.getGiving(), p);
+        visit(addToGiving.getRoundables(), p);
+        return addToGiving;
     }
 
     public Cobol visitAlphabetAlso(Cobol.AlphabetAlso alphabetAlso, PrintOutputCapture<P> p) {
@@ -466,7 +487,8 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitSpace(collatingSequenceClause.getPrefix(), p);
         visitMarkers(collatingSequenceClause.getMarkers(), p);
         visit(collatingSequenceClause.getWords(), p);
-        visitContainer("", collatingSequenceClause.getPadding().getAlphabetName(), "", "", p);
+        visit(collatingSequenceClause.getIs(), p);
+        visit(collatingSequenceClause.getAlphabetName(), p);
         visit(collatingSequenceClause.getAlphanumeric(), p);
         visit(collatingSequenceClause.getNational(), p);
         return collatingSequenceClause;
@@ -597,7 +619,7 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitMarkers(currencyClause.getMarkers(), p);
         visit(currencyClause.getWords(), p);
         visit(currencyClause.getLiteral(), p);
-        visitLeftPadded("", currencyClause.getPadding().getPictureSymbol(), p);
+        visit(currencyClause.getPictureSymbols(), p);
         visit(currencyClause.getPictureSymbolLiteral(), p);
         return currencyClause;
     }
@@ -1791,7 +1813,8 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visitMarkers(moveCorrespondingToStatement.getMarkers(), p);
         visit(moveCorrespondingToStatement.getWords(), p);
         visit(moveCorrespondingToStatement.getMoveCorrespondingToSendingArea(), p);
-        visitContainer("", moveCorrespondingToStatement.getPadding().getTo(), "", "", p);
+        visit(moveCorrespondingToStatement.getTo(), p);
+        visit(moveCorrespondingToStatement.getIdentifiers(), p);
         return moveCorrespondingToStatement;
     }
 
@@ -1861,7 +1884,9 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
     public Cobol visitMultiplyGiving(Cobol.MultiplyGiving multiplyGiving, PrintOutputCapture<P> p) {
         visitSpace(multiplyGiving.getPrefix(), p);
         visitMarkers(multiplyGiving.getMarkers(), p);
-        visitContainer("", multiplyGiving.getPadding().getResult(), "", "", p);
+        visit(multiplyGiving.getOperand(), p);
+        visit(multiplyGiving.getGiving(), p);
+        visit(multiplyGiving.getResult(), p);
         return multiplyGiving;
     }
 
@@ -2275,7 +2300,8 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
     public Cobol visitPurge(Cobol.Purge purge, PrintOutputCapture<P> p) {
         visitSpace(purge.getPrefix(), p);
         visitMarkers(purge.getMarkers(), p);
-        visitContainer("", purge.getPadding().getNames(), "", "", p);
+        visit(purge.getPurge(), p);
+        visit(purge.getNames(), p);
         return purge;
     }
 
@@ -3311,8 +3337,9 @@ public class CobolPrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
     public Cobol visitSetTo(Cobol.SetTo setTo, PrintOutputCapture<P> p) {
         visitSpace(setTo.getPrefix(), p);
         visitMarkers(setTo.getMarkers(), p);
+        visit(setTo.getIdentifiers(), p);
         visit(setTo.getTo(), p);
-        visitContainer("", setTo.getPadding().getValues(), "", "", p);
+        visit(setTo.getValues(), p);
         return setTo;
     }
 

--- a/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -337,98 +337,71 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    class AddTo implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
+    @With
+    class AddCorresponding implements Statement {
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
+        CobolWord corresponding;
+        Identifier identifier;
+        CobolWord to;
+        Roundable roundable;
 
-        @Getter
-        @With
+        @Override
+        public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
+            return v.visitAddCorresponding(this, p);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class AddTo implements Cobol {
+
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+        Markers markers;
         List<Name> from;
-
-        @Nullable
-        CobolContainer<Name> to;
-
-        @Nullable
-        CobolContainer<Name> giving;
+        CobolWord to;
+        List<Name> roundables;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitAddTo(this, p);
         }
+    }
 
-        public List<Name> getTo() {
-            return to.getElements();
-        }
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class AddToGiving implements Cobol {
 
-        public AddTo withTo(List<Name> to) {
-            return getPadding().withTo(this.to.getPadding().withElements(CobolRightPadded.withElements(
-                    this.to.getPadding().getElements(), to)));
-        }
+        @EqualsAndHashCode.Include
+        UUID id;
 
-        public List<Name> getGiving() {
-            return giving.getElements();
-        }
+        Space prefix;
+        Markers markers;
+        List<Name> from;
 
-        public AddTo withGiving(List<Name> giving) {
-            return getPadding().withGiving(this.giving.getPadding().withElements(CobolRightPadded.withElements(
-                    this.giving.getPadding().getElements(), giving)));
-        }
+        @Nullable
+        CobolWord to;
 
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
+        @Nullable
+        List<Name> names;
 
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final AddTo t;
+        CobolWord giving;
+        List<Name> roundables;
 
-            @Nullable
-            public CobolContainer<Name> getTo() {
-                return t.to;
-            }
-
-            public AddTo withTo(@Nullable CobolContainer<Name> to) {
-                return t.to == to ? t : new AddTo(t.padding, t.id, t.prefix, t.markers, t.from, to, t.giving);
-            }
-
-            @Nullable
-            public CobolContainer<Name> getGiving() {
-                return t.giving;
-            }
-
-            public AddTo withGiving(@Nullable CobolContainer<Name> giving) {
-                return t.giving == giving ? t : new AddTo(t.padding, t.id, t.prefix, t.markers, t.from, t.to, giving);
-            }
+        @Override
+        public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
+            return v.visitAddToGiving(this, p);
         }
     }
 
@@ -1210,86 +1183,29 @@ public interface Cobol extends Tree {
         }
     }
 
-
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class CollatingSequenceClause implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         List<CobolWord> words;
+        CobolWord is;
+        List<Identifier> alphabetName;
 
-        CobolContainer<Identifier> alphabetName;
-
-        @Getter
         @Nullable
-        @With
         CollatingSequenceAlphabet alphanumeric;
 
-        @Getter
         @Nullable
-        @With
         CollatingSequenceAlphabet national;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitCollatingSequenceClause(this, p);
-        }
-
-        public List<Identifier> getAlphabetName() {
-            return alphabetName.getElements();
-        }
-
-        public CollatingSequenceClause withAlphabetName(List<Identifier> alphabetName) {
-            return getPadding().withAlphabetName(this.alphabetName.getPadding().withElements(CobolRightPadded.withElements(
-                    this.alphabetName.getPadding().getElements(), alphabetName)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final CollatingSequenceClause t;
-
-            public CobolContainer<Identifier> getAlphabetName() {
-                return t.alphabetName;
-            }
-
-            public CollatingSequenceClause withAlphabetName(CobolContainer<Identifier> alphabetName) {
-                return t.alphabetName == alphabetName ? t : new CollatingSequenceClause(t.padding, t.id, t.prefix, t.markers, t.words, alphabetName, t.alphanumeric, t.national);
-            }
         }
     }
 
@@ -1566,89 +1482,28 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class CurrencyClause implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         List<CobolWord> words;
-
-        @Getter
-        @With
         Literal literal;
 
         @Nullable
-        CobolLeftPadded<CobolWord> pictureSymbol;
+        List<CobolWord> pictureSymbols;
 
-        @Getter
         @Nullable
-        @With
         Literal pictureSymbolLiteral;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitCurrencyClause(this, p);
-        }
-
-        @Nullable
-        public CobolWord getPictureSymbol() {
-            return pictureSymbol == null ? null : pictureSymbol.getElement();
-        }
-
-        public CurrencyClause withPictureSymbol(@Nullable CobolWord pictureSymbol) {
-            if (pictureSymbol == null) {
-                return this.pictureSymbol == null ? this : new CurrencyClause(id, prefix, markers, words, literal, null, pictureSymbolLiteral);
-            }
-            return getPadding().withPictureSymbol(CobolLeftPadded.withElement(this.pictureSymbol, pictureSymbol));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final CurrencyClause t;
-
-            @Nullable
-            public CobolLeftPadded<CobolWord> getPictureSymbol() {
-                return t.pictureSymbol;
-            }
-
-            public CurrencyClause withPictureSymbol(@Nullable CobolLeftPadded<CobolWord> pictureSymbol) {
-                return t.pictureSymbol == pictureSymbol ? t : new CurrencyClause(t.padding, t.id, t.prefix, t.markers, t.words, t.literal, pictureSymbol, t.pictureSymbolLiteral);
-            }
         }
     }
 
@@ -2689,81 +2544,26 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class Entry implements Statement {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord entry;
-
-        @Getter
-        @With
         Literal literal;
+        CobolWord using;
 
         @Nullable
-        CobolContainer<Identifier> identifiers;
+        List<Identifier> identifiers;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitEntry(this, p);
-        }
-
-        public List<Identifier> getIdentifiers() {
-            return identifiers.getElements();
-        }
-
-        public Entry withIdentifiers(List<Identifier> identifiers) {
-            return getPadding().withIdentifiers(this.identifiers.getPadding().withElements(CobolRightPadded.withElements(
-                    this.identifiers.getPadding().getElements(), identifiers)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final Entry t;
-
-            @Nullable
-            public CobolContainer<Identifier> getIdentifiers() {
-                return t.identifiers;
-            }
-
-            public Entry withIdentifiers(@Nullable CobolContainer<Identifier> identifiers) {
-                return t.identifiers == identifiers ? t : new Entry(t.padding, t.id, t.prefix, t.markers, t.entry, t.literal, identifiers);
-            }
         }
     }
 
@@ -4926,79 +4726,24 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class MoveCorrespondingToStatement implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord words;
-
-        @Getter
-        @With
         Identifier moveCorrespondingToSendingArea;
-
-        CobolContainer<Identifier> to;
+        CobolWord to;
+        List<Identifier> identifiers;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitMoveCorrespondingToStatement(this, p);
-        }
-
-        public List<Identifier> getTo() {
-            return to.getElements();
-        }
-
-        public MoveCorrespondingToStatement withTo(List<Identifier> to) {
-            return getPadding().withTo(this.to.getPadding().withElements(CobolRightPadded.withElements(
-                    this.to.getPadding().getElements(), to)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final MoveCorrespondingToStatement t;
-
-            public CobolContainer<Identifier> getTo() {
-                return t.to;
-            }
-
-            public MoveCorrespondingToStatement withTo(CobolContainer<Identifier> to) {
-                return t.to == to ? t : new MoveCorrespondingToStatement(t.padding, t.id, t.prefix, t.markers, t.words, t.moveCorrespondingToSendingArea, to);
-            }
         }
     }
 
@@ -5150,75 +4895,23 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class MultiplyGiving implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         Name operand;
-
-        CobolContainer<Roundable> result;
+        CobolWord giving;
+        List<Roundable> result;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitMultiplyGiving(this, p);
-        }
-
-        public List<Cobol.Roundable> getResult() {
-            return result.getElements();
-        }
-
-        public MultiplyGiving withResult(List<Cobol.Roundable> result) {
-            return getPadding().withResult(this.result.getPadding().withElements(CobolRightPadded.withElements(
-                    this.result.getPadding().getElements(), result)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final MultiplyGiving t;
-
-            public CobolContainer<Cobol.Roundable> getResult() {
-                return t.result;
-            }
-
-            public MultiplyGiving withResult(CobolContainer<Cobol.Roundable> result) {
-                return t.result == result ? t : new MultiplyGiving(t.padding, t.id, t.prefix, t.markers, t.operand, result);
-            }
         }
     }
 
@@ -6286,71 +5979,22 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class Purge implements Statement {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        CobolContainer<Name> names;
+        CobolWord purge;
+        List<Name> names;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitPurge(this, p);
-        }
-
-        public List<Name> getNames() {
-            return names.getElements();
-        }
-
-        public Purge withNames(List<Name> names) {
-            return getPadding().withNames(this.names.getPadding().withElements(CobolRightPadded.withElements(
-                    this.names.getPadding().getElements(), names)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final Purge t;
-
-            public CobolContainer<Name> getNames() {
-                return t.names;
-            }
-
-            public Purge withNames(CobolContainer<Name> names) {
-                return t.names == names ? t : new Purge(t.padding, t.id, t.prefix, t.markers, names);
-            }
         }
     }
 
@@ -8924,75 +8568,23 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class SetTo implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
-        List<Identifier> to;
-
-        CobolContainer<Name> values;
+        List<Identifier> identifiers;
+        CobolWord to;
+        List<Name> values;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitSetTo(this, p);
-        }
-
-        public List<Name> getValues() {
-            return values.getElements();
-        }
-
-        public SetTo withValues(List<Name> values) {
-            return getPadding().withValues(this.values.getPadding().withElements(CobolRightPadded.withElements(
-                    this.values.getPadding().getElements(), values)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final SetTo t;
-
-            public CobolContainer<Name> getValues() {
-                return t.values;
-            }
-
-            public SetTo withValues(CobolContainer<Name> values) {
-                return t.values == values ? t : new SetTo(t.padding, t.id, t.prefix, t.markers, t.to, values);
-            }
         }
     }
 

--- a/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -57,47 +57,28 @@ public interface Cobol extends Tree {
 
     Markers getMarkers();
 
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class CompilationUnit implements Cobol, SourceFile {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
-
-        @With
         @EqualsAndHashCode.Include
-        @Getter
         UUID id;
 
-        @With
-        @Getter
         Path sourcePath;
 
-        @With
-        @Getter
-        @Nullable FileAttributes fileAttributes;
+        @Nullable
+        FileAttributes fileAttributes;
 
-        @With
-        @Getter
         Space prefix;
-
-        @With
-        @Getter
         Markers markers;
-
         @Nullable // for backwards compatibility
         @With(AccessLevel.PRIVATE)
         String charsetName;
 
-        @With
-        @Getter
         boolean charsetBomMarked;
 
-        @With
-        @Getter
-        @Nullable Checksum checksum;
+        @Nullable
+        Checksum checksum;
 
         @Override
         public Charset getCharset() {
@@ -109,18 +90,7 @@ public interface Cobol extends Tree {
             return withCharsetName(charset.name());
         }
 
-        List<CobolRightPadded<ProgramUnit>> programUnits;
-
-        public List<ProgramUnit> getProgramUnits() {
-            return CobolRightPadded.getElements(programUnits);
-        }
-
-        public CompilationUnit withProgramUnits(List<ProgramUnit> body) {
-            return getPadding().withProgramUnits(CobolRightPadded.withElements(this.programUnits, body));
-        }
-
-        @With
-        @Getter
+        List<ProgramUnit> programUnits;
         String eof;
 
         @Override
@@ -131,34 +101,6 @@ public interface Cobol extends Tree {
         @Override
         public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
             return new CobolPrinter<>();
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final CompilationUnit t;
-
-            public List<CobolRightPadded<ProgramUnit>> getProgramUnits() {
-                return t.programUnits;
-            }
-
-            public CompilationUnit withProgramUnits(List<CobolRightPadded<ProgramUnit>> programUnits) {
-                return t.programUnits == programUnits ? t : new CompilationUnit(t.id, t.sourcePath, t.fileAttributes, t.prefix, t.markers, t.charsetName, t.charsetBomMarked, t.checksum, programUnits, t.eof);
-            }
         }
     }
 
@@ -397,7 +339,7 @@ public interface Cobol extends Tree {
         List<Name> names;
 
         CobolWord giving;
-        List<Name> roundables;
+        List<Roundable> roundables;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
@@ -489,75 +431,21 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class AlteredGoTo implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
-
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
-        CobolWord words;
-
-        CobolLeftPadded<CobolWord> dot;
+        List<CobolWord> words;
+        CobolWord dot;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitAlteredGoTo(this, p);
-        }
-
-        public CobolWord getDot() {
-            return dot.getElement();
-        }
-
-        public AlteredGoTo withDot(CobolWord dot) {
-            //noinspection ConstantConditions
-            return getPadding().withDot(CobolLeftPadded.withElement(this.dot, dot));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final AlteredGoTo t;
-
-            public CobolLeftPadded<CobolWord> getDot() {
-                return t.dot;
-            }
-
-            public AlteredGoTo withDot(CobolLeftPadded<CobolWord> dot) {
-                return t.dot == dot ? t : new AlteredGoTo(t.padding, t.id, t.prefix, t.markers, t.words, dot);
-            }
         }
     }
 
@@ -1409,34 +1297,17 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @AllArgsConstructor
+    @With
     class ConditionNameSubscriptReference implements Cobol {
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord leftParen;
-
-        @Getter
-        @With
         List<Cobol> subscripts;
-
-        @Getter
-        @With
         CobolWord rightParen;
 
         @Override
@@ -1716,96 +1587,32 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class DataOccursClause implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
-
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord occurs;
-
-        @Getter
-        @With
         Name name;
 
-        @Getter
         @Nullable
-        @With
         DataOccursTo dataOccursTo;
 
-        @Getter
         @Nullable
-        @With
         CobolWord times;
 
-        @Getter
         @Nullable
-        @With
         DataOccursDepending dataOccursDepending;
-
         @Nullable
-        CobolContainer<Cobol> sortIndexed;
+        List<Cobol> sortIndexed;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitDataOccursClause(this, p);
-        }
-
-        public List<Cobol> getSortIndexed() {
-            return sortIndexed.getElements();
-        }
-
-        public DataOccursClause withSortIndexed(List<Cobol> sortIndexed) {
-            return getPadding().withSortIndexed(this.sortIndexed.getPadding().withElements(CobolRightPadded.withElements(
-                    this.sortIndexed.getPadding().getElements(), sortIndexed)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final DataOccursClause t;
-
-            @Nullable
-            public CobolContainer<Cobol> getSortIndexed() {
-                return t.sortIndexed;
-            }
-
-            public DataOccursClause withSortIndexed(@Nullable CobolContainer<Cobol> sortIndexed) {
-                return t.sortIndexed == sortIndexed ? t : new DataOccursClause(t.padding, t.id, t.prefix, t.markers, t.occurs, t.name, t.dataOccursTo, t.times, t.dataOccursDepending, sortIndexed);
-            }
         }
     }
 
@@ -2537,6 +2344,7 @@ public interface Cobol extends Tree {
         Markers markers;
         List<CobolWord> words;
         Name programName;
+        CobolWord dot;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
@@ -3430,75 +3238,22 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class InspectAllLeadings implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord word;
-
-        CobolContainer<InspectAllLeading> leadings;
+        List<InspectAllLeading> leadings;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitInspectAllLeadings(this, p);
-        }
-
-        public List<Cobol.InspectAllLeading> getLeadings() {
-            return leadings.getElements();
-        }
-
-        public InspectAllLeadings withLeadings(List<Cobol.InspectAllLeading> leadings) {
-            return getPadding().withLeadings(this.leadings.getPadding().withElements(CobolRightPadded.withElements(
-                    this.leadings.getPadding().getElements(), leadings)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final InspectAllLeadings t;
-
-            public CobolContainer<Cobol.InspectAllLeading> getLeadings() {
-                return t.leadings;
-            }
-
-            public InspectAllLeadings withLeadings(CobolContainer<Cobol.InspectAllLeading> leadings) {
-                return t.leadings == leadings ? t : new InspectAllLeadings(t.padding, t.id, t.prefix, t.markers, t.word, leadings);
-            }
         }
     }
 
@@ -3582,79 +3337,23 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class InspectFor implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         Identifier identifier;
-
-        @Getter
-        @With
         CobolWord word;
-
-        CobolContainer<Cobol> inspects;
+        List<Cobol> inspects;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitInspectFor(this, p);
-        }
-
-        public List<Cobol> getInspects() {
-            return inspects.getElements();
-        }
-
-        public InspectFor withInspects(List<Cobol> inspects) {
-            return getPadding().withInspects(this.inspects.getPadding().withElements(CobolRightPadded.withElements(
-                    this.inspects.getPadding().getElements(), inspects)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final InspectFor t;
-
-            public CobolContainer<Cobol> getInspects() {
-                return t.inspects;
-            }
-
-            public InspectFor withInspects(CobolContainer<Cobol> inspects) {
-                return t.inspects == inspects ? t : new InspectFor(t.padding, t.id, t.prefix, t.markers, t.identifier, t.word, inspects);
-            }
         }
     }
 
@@ -3721,75 +3420,22 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class InspectReplacingPhrase implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord word;
-
-        CobolContainer<Cobol> inspections;
+        List<Cobol> inspections;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitInspectReplacingPhrase(this, p);
-        }
-
-        public List<Cobol> getInspections() {
-            return inspections.getElements();
-        }
-
-        public InspectReplacingPhrase withInspections(List<Cobol> inspections) {
-            return getPadding().withInspections(this.inspections.getPadding().withElements(CobolRightPadded.withElements(
-                    this.inspections.getPadding().getElements(), inspections)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final InspectReplacingPhrase t;
-
-            public CobolContainer<Cobol> getInspections() {
-                return t.inspections;
-            }
-
-            public InspectReplacingPhrase withInspections(CobolContainer<Cobol> inspections) {
-                return t.inspections == inspections ? t : new InspectReplacingPhrase(t.padding, t.id, t.prefix, t.markers, t.word, inspections);
-            }
         }
     }
 
@@ -3867,91 +3513,32 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class IoControlParagraph implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord iOControl;
-
-        @Getter
-        @With
         CobolWord dot;
 
-        @Getter
         @Nullable
-        @With
         CobolWord fileName;
 
-        @Getter
         @Nullable
-        @With
         CobolWord fileNameDot;
-
         @Nullable
-        CobolContainer<Cobol> clauses;
+        List<Cobol> clauses;
+
+        CobolWord dot2;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitIoControlParagraph(this, p);
-        }
-
-        public List<Cobol> getClauses() {
-            return clauses.getElements();
-        }
-
-        public IoControlParagraph withClauses(List<Cobol> clauses) {
-            return getPadding().withClauses(this.clauses.getPadding().withElements(CobolRightPadded.withElements(
-                    this.clauses.getPadding().getElements(), clauses)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final IoControlParagraph t;
-
-            @Nullable
-            public CobolContainer<Cobol> getClauses() {
-                return t.clauses;
-            }
-
-            public IoControlParagraph withClauses(@Nullable CobolContainer<Cobol> clauses) {
-                return t.clauses == clauses ? t : new IoControlParagraph(t.padding, t.id, t.prefix, t.markers, t.iOControl, t.dot, t.fileName, t.fileNameDot, clauses);
-            }
         }
     }
 
@@ -4102,95 +3689,32 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class LibraryDescriptionEntryFormat2 implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord lb;
-
-        @Getter
-        @With
         CobolWord libraryName;
-
-        @Getter
-        @With
         CobolWord export;
 
-        @Getter
         @Nullable
-        @With
         LibraryIsGlobalClause libraryIsGlobalClause;
 
-        @Getter
         @Nullable
-        @With
         LibraryIsCommonClause libraryIsCommonClause;
 
         @Nullable
-        CobolContainer<Cobol> clauseFormats;
+        List<Cobol> clauseFormats;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitLibraryDescriptionEntryFormat2(this, p);
-        }
-
-        public List<Cobol> getClauseFormats() {
-            return clauseFormats.getElements();
-        }
-
-        public LibraryDescriptionEntryFormat2 withClauseFormats(List<Cobol> clauseFormats) {
-            return getPadding().withClauseFormats(this.clauseFormats.getPadding().withElements(CobolRightPadded.withElements(
-                    this.clauseFormats.getPadding().getElements(), clauseFormats)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final LibraryDescriptionEntryFormat2 t;
-
-            @Nullable
-            public CobolContainer<Cobol> getClauseFormats() {
-                return t.clauseFormats;
-            }
-
-            public LibraryDescriptionEntryFormat2 withClauseFormats(@Nullable CobolContainer<Cobol> clauseFormats) {
-                return t.clauseFormats == clauseFormats ? t : new LibraryDescriptionEntryFormat2(t.padding, t.id, t.prefix, t.markers, t.lb, t.libraryName, t.export, t.libraryIsGlobalClause, t.libraryIsCommonClause, clauseFormats);
-            }
         }
     }
 
@@ -5011,75 +4535,22 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class Open implements Statement {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord words;
-
-        CobolContainer<Cobol> open;
+        List<Cobol> open;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitOpen(this, p);
-        }
-
-        public List<Cobol> getOpen() {
-            return open.getElements();
-        }
-
-        public Open withOpen(List<Cobol> open) {
-            return getPadding().withOpen(this.open.getPadding().withElements(CobolRightPadded.withElements(
-                    this.open.getPadding().getElements(), open)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final Open t;
-
-            public CobolContainer<Cobol> getOpen() {
-                return t.open;
-            }
-
-            public Open withOpen(CobolContainer<Cobol> open) {
-                return t.open == open ? t : new Open(t.padding, t.id, t.prefix, t.markers, t.words, open);
-            }
         }
     }
 
@@ -5882,100 +5353,35 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class ProgramUnit implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
 
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         IdentificationDivision identificationDivision;
 
-        @Getter
         @Nullable
-        @With
         EnvironmentDivision environmentDivision;
 
-        @Getter
         @Nullable
-        @With
         DataDivision dataDivision;
 
-        @Getter
         @Nullable
-        @With
         ProcedureDivision procedureDivision;
 
-        @Getter
         @Nullable
-        @With
         List<ProgramUnit> programUnits;
-
         @Nullable
-        CobolRightPadded<EndProgram> endProgram;
+        EndProgram endProgram;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitProgramUnit(this, p);
-        }
-
-        @Nullable
-        public Cobol.EndProgram getEndProgram() {
-            return endProgram == null ? null : endProgram.getElement();
-        }
-
-        public ProgramUnit withEndProgram(@Nullable Cobol.EndProgram endProgram) {
-            if (endProgram == null) {
-                return this.endProgram == null ? this : new ProgramUnit(id, prefix, markers, identificationDivision, environmentDivision, dataDivision, procedureDivision, programUnits, null);
-            }
-            return getPadding().withEndProgram(CobolRightPadded.withElement(this.endProgram, endProgram));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final ProgramUnit t;
-
-            @Nullable
-            public CobolRightPadded<Cobol.EndProgram> getEndProgram() {
-                return t.endProgram;
-            }
-
-            public ProgramUnit withEndProgram(@Nullable CobolRightPadded<Cobol.EndProgram> endProgram) {
-                return t.endProgram == endProgram ? t : new ProgramUnit(t.padding, t.id, t.prefix, t.markers, t.identificationDivision, t.environmentDivision, t.dataDivision, t.procedureDivision, t.programUnits, endProgram);
-            }
         }
     }
 
@@ -6270,83 +5676,23 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class ReceiveFromStatement implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
-
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord dataName;
-
-        @Getter
-        @With
         CobolWord from;
-
-        @Getter
-        @With
         ReceiveFrom receiveFrom;
-
-        CobolContainer<Cobol> beforeWithThreadSizeStatus;
+        List<Cobol> beforeWithThreadSizeStatus;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitReceiveFromStatement(this, p);
-        }
-
-        public List<Cobol> getBeforeWithThreadSizeStatus() {
-            return beforeWithThreadSizeStatus.getElements();
-        }
-
-        public ReceiveFromStatement withBeforeWithThreadSizeStatus(List<Cobol> beforeWithThreadSizeStatus) {
-            return getPadding().withBeforeWithThreadSizeStatus(this.beforeWithThreadSizeStatus.getPadding().withElements(CobolRightPadded.withElements(
-                    this.beforeWithThreadSizeStatus.getPadding().getElements(), beforeWithThreadSizeStatus)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final ReceiveFromStatement t;
-
-            public CobolContainer<Cobol> getBeforeWithThreadSizeStatus() {
-                return t.beforeWithThreadSizeStatus;
-            }
-
-            public ReceiveFromStatement withBeforeWithThreadSizeStatus(CobolContainer<Cobol> beforeWithThreadSizeStatus) {
-                return t.beforeWithThreadSizeStatus == beforeWithThreadSizeStatus ? t : new ReceiveFromStatement(t.padding, t.id, t.prefix, t.markers, t.dataName, t.from, t.receiveFrom, beforeWithThreadSizeStatus);
-            }
         }
     }
 
@@ -6979,86 +6325,27 @@ public interface Cobol extends Tree {
         }
     }
 
-    @ToString
-    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @RequiredArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @With
     class ReportGroupDescriptionEntryFormat3 implements Cobol {
-        @Nullable
-        @NonFinal
-        transient WeakReference<Padding> padding;
-
-        @Getter
         @EqualsAndHashCode.Include
-        @With
         UUID id;
 
-        @Getter
-        @With
         Space prefix;
-
-        @Getter
-        @With
         Markers markers;
-
-        @Getter
-        @With
         CobolWord integerLiteral;
 
-        @Getter
         @Nullable
-        @With
         CobolWord dataName;
 
         @Nullable
-        CobolContainer<Cobol> clauses;
+        List<Cobol> clauses;
 
-        @Getter
-        @With
         CobolWord dot;
-
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitReportGroupDescriptionEntryFormat3(this, p);
-        }
-
-        public List<Cobol> getClauses() {
-            return clauses.getElements();
-        }
-
-        public ReportGroupDescriptionEntryFormat3 withClauses(List<Cobol> clauses) {
-            return getPadding().withClauses(this.clauses.getPadding().withElements(CobolRightPadded.withElements(
-                    this.clauses.getPadding().getElements(), clauses)));
-        }
-
-        public Padding getPadding() {
-            Padding p;
-            if (this.padding == null) {
-                p = new Padding(this);
-                this.padding = new WeakReference<>(p);
-            } else {
-                p = this.padding.get();
-                if (p == null || p.t != this) {
-                    p = new Padding(this);
-                    this.padding = new WeakReference<>(p);
-                }
-            }
-            return p;
-        }
-
-        @RequiredArgsConstructor
-        public static class Padding {
-            private final ReportGroupDescriptionEntryFormat3 t;
-
-            @Nullable
-            public CobolContainer<Cobol> getClauses() {
-                return t.clauses;
-            }
-
-            public ReportGroupDescriptionEntryFormat3 withClauses(@Nullable CobolContainer<Cobol> clauses) {
-                return t.clauses == clauses ? t : new ReportGroupDescriptionEntryFormat3(t.padding, t.id, t.prefix, t.markers, t.integerLiteral, t.dataName, clauses, t.dot);
-            }
         }
     }
 
@@ -9753,6 +9040,18 @@ public interface Cobol extends Tree {
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitValuePair(this, p);
         }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Words implements Cobol {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+        Markers markers;
+        List<CobolWord> words;
     }
 
     @Value


### PR DESCRIPTION
- Added missing classes: AddCorresponding, AddToGiving.
- Added Words to replace classes that only contain a list of words.
- Removed LeftPadded, RightPadded, Container, and associated methods. (A token like `.` may be surrounded by relevant source code that needs to be represented by markers).