### PR TITLE
Copybooks as cobol sources

### DIFF
--- a/publish-nist-asts/src/main/java/io/moderne/cobol/CreateNistAstJar.java
+++ b/publish-nist-asts/src/main/java/io/moderne/cobol/CreateNistAstJar.java
@@ -6,8 +6,8 @@ import org.openrewrite.*;
 import org.openrewrite.cobol.CobolParser;
 import org.openrewrite.cobol.CobolPreprocessorParser;
 import org.openrewrite.cobol.internal.CobolDialect;
-import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.cobol.tree.CobolPreprocessor;
+import org.openrewrite.cobol.tree.CobolSourceFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -59,7 +59,7 @@ public class CreateNistAstJar {
                 .build();
         System.out.println("Parsing " + sources.size() + " COBOL sources");
         start = Instant.now();
-        List<Cobol.CompilationUnit> cus =  cp.parseInputs(sources, null, ctx);
+        List<CobolSourceFile> cus =  cp.parseInputs(sources, null, ctx);
         System.out.println("Parsed sources into " + cus.size() + " Compilation Units in " +
                 prettyPrint(Duration.between(start, Instant.now())));
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolIsoVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolIsoVisitor.java
@@ -2303,6 +2303,11 @@ public class CobolIsoVisitor<P> extends CobolVisitor<P> {
 
     /* Cobol$Preprocessor visits */
     @Override
+    public Cobol.Preprocessor.CopyBook visitCopyBook(Cobol.Preprocessor.CopyBook copyBook, P p) {
+        return (Cobol.Preprocessor.CopyBook) super.visitCopyBook(copyBook, p);
+    }
+
+    @Override
     public Cobol.Preprocessor.CharData visitCharData(Cobol.Preprocessor.CharData charData, P p) {
         return (Cobol.Preprocessor.CharData) super.visitCharData(charData, p);
     }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolParser.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolParser.java
@@ -70,7 +70,7 @@ public class CobolParser implements Parser<Cobol.CompilationUnit> {
                             .tag("file.type", "COBOL");
                     Timer.Sample sample = Timer.start();
                     try {
-                        EncodingDetectingInputStream is = sourceFile.getSource();
+                        EncodingDetectingInputStream is = sourceFile.getSource(ctx);
 
                         CobolPreprocessorParser cobolPreprocessorParser = CobolPreprocessorParser.builder()
                                 .setCobolDialect(cobolDialect)

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolPreprocessorIsoVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolPreprocessorIsoVisitor.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.cobol;
 
-import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.cobol.tree.CobolPreprocessor;
 
 public class CobolPreprocessorIsoVisitor<P> extends CobolPreprocessorVisitor<P> {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolPreprocessorParser.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolPreprocessorParser.java
@@ -85,7 +85,7 @@ public class CobolPreprocessorParser implements Parser<CobolPreprocessor.Compila
                             .tag("file.type", "COBOL");
                     Timer.Sample sample = Timer.start();
                     try {
-                        EncodingDetectingInputStream is = sourceFile.getSource();
+                        EncodingDetectingInputStream is = sourceFile.getSource(ctx);
                         String sourceStr = is.readFully();
 
                         String prepareSource = new CobolLineReader().readLines(sourceStr, cobolDialect);
@@ -295,23 +295,6 @@ public class CobolPreprocessorParser implements Parser<CobolPreprocessor.Compila
         @Override
         public String getDslName() {
             return "preprocessCobol";
-        }
-    }
-
-    private static class ForwardingErrorListener extends BaseErrorListener {
-        private final Path sourcePath;
-        private final ExecutionContext ctx;
-
-        private ForwardingErrorListener(Path sourcePath, ExecutionContext ctx) {
-            this.sourcePath = sourcePath;
-            this.ctx = ctx;
-        }
-
-        @Override
-        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
-                                int line, int charPositionInLine, String msg, RecognitionException e) {
-            ctx.getOnError().accept(new CobolParsingException(sourcePath,
-                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath, line, charPositionInLine, msg), e));
         }
     }
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolVisitor.java
@@ -4400,6 +4400,15 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
     }
 
     /* Cobol$Preprocessor visits */
+    public Cobol visitCopyBook(Cobol.Preprocessor.CopyBook copyBook, P p) {
+        Cobol.Preprocessor.CopyBook c = copyBook;
+        c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.COPY_BOOK_PREFIX, p));
+        c = c.withMarkers(visitMarkers(c.getMarkers(), p));
+        c = c.withAst(visit(c.getAst(), p));
+        c = c.withEof((Cobol.Word) visit(c.getEof(), p));
+        return c;
+    }
+
     public Cobol visitCharData(Cobol.Preprocessor.CharData charData, P p) {
         Cobol.Preprocessor.CharData c = charData;
         c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.CHAR_DATA_PREFIX, p));

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -7108,8 +7108,9 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
             return copyBooks.stream().map(CobolPreprocessorConverter::convertCopyBook).collect(Collectors.toList());
         }
 
-        private static Cobol.Preprocessor.CopyBook convertCopyBook(CobolPreprocessor.CopyBook copyBook) {
-            return new Cobol.Preprocessor.CopyBook(
+        @Nullable
+        private static Cobol.Preprocessor.CopyBook convertCopyBook(@Nullable CobolPreprocessor.CopyBook copyBook) {
+            return copyBook == null ? null : new Cobol.Preprocessor.CopyBook(
                     copyBook.getId(),
                     copyBook.getSourcePath(),
                     copyBook.getFileAttributes(),
@@ -7201,7 +7202,8 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                     convertWord(copyStatement.getWord()),
                     convertCopySource(copyStatement.getCopySource()),
                     convertAll(copyStatement.getCobols()),
-                    convertWord(copyStatement.getDot()));
+                    convertWord(copyStatement.getDot()),
+                    convertCopyBook(copyStatement.getCopyBook()));
         }
 
         private static Cobol.Preprocessor.DirectoryPhrase convertDirectoryPhrase(CobolPreprocessor.DirectoryPhrase directoryPhrase) {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -7103,7 +7103,25 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         return null;
     }
 
-    private static class CobolPreprocessorConverter {
+    public static class CobolPreprocessorConverter {
+        public static List<Cobol.Preprocessor.CopyBook> convertAllCopybooks(List<CobolPreprocessor.CopyBook> copyBooks) {
+            return copyBooks.stream().map(CobolPreprocessorConverter::convertCopyBook).collect(Collectors.toList());
+        }
+
+        private static Cobol.Preprocessor.CopyBook convertCopyBook(CobolPreprocessor.CopyBook copyBook) {
+            return new Cobol.Preprocessor.CopyBook(
+                    copyBook.getId(),
+                    copyBook.getSourcePath(),
+                    copyBook.getFileAttributes(),
+                    copyBook.getPrefix(),
+                    copyBook.getMarkers(),
+                    copyBook.getCharsetName(),
+                    copyBook.isCharsetBomMarked(),
+                    copyBook.getChecksum(),
+                    convert(copyBook.getAst()),
+                    convertWord(copyBook.getEof()));
+        }
+
         @Nullable
         private static Cobol.Preprocessor.CharData convertCharData(@Nullable CobolPreprocessor.CharData charData) {
             return charData == null ? null : new Cobol.Preprocessor.CharData(

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -7119,8 +7119,9 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                     copyBook.getCharsetName(),
                     copyBook.isCharsetBomMarked(),
                     copyBook.getChecksum(),
-                    convert(copyBook.getAst()),
-                    convertWord(copyBook.getEof()));
+                    // The product of the CopyBook already exists in the CobolTree, and is not needed in the CopyBook CobolSourceFile.
+                    null,
+                    null);
         }
 
         @Nullable
@@ -7203,7 +7204,10 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                     convertCopySource(copyStatement.getCopySource()),
                     convertAll(copyStatement.getCobols()),
                     convertWord(copyStatement.getDot()),
-                    convertCopyBook(copyStatement.getCopyBook()));
+                    convertCopyBook(copyStatement.getCopyBook()
+                            // The CopyBook is only used as meta data like type attribution to link the copy statement to the CopyBook source.
+                            .withAst(null)
+                            .withEof(null)));
         }
 
         private static Cobol.Preprocessor.DirectoryPhrase convertDirectoryPhrase(CobolPreprocessor.DirectoryPhrase directoryPhrase) {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
@@ -4520,6 +4520,14 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
     /* Cobol preprocessor visits */
 
     @Override
+    public Cobol visitCopyBook(Cobol.Preprocessor.CopyBook copyBook, PrintOutputCapture<P> p) {
+        beforeSyntax(copyBook, Space.Location.COPY_BOOK_PREFIX, p);
+        visit(copyBook.getAst(), p);
+        visit(copyBook.getEof(), p);
+        return copyBook;
+    }
+
+    @Override
     public Cobol visitCharData( Cobol.Preprocessor.CharData charData, PrintOutputCapture<P> p) {
         beforeSyntax(charData, Space.Location.CHAR_DATA_PREFIX, p);
         visit(charData.getCobols(), p);

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
@@ -4524,6 +4524,7 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         beforeSyntax(copyBook, Space.Location.COPY_BOOK_PREFIX, p);
         visit(copyBook.getAst(), p);
         visit(copyBook.getEof(), p);
+        afterSyntax(copyBook, p);
         return copyBook;
     }
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -53,7 +53,7 @@ public interface Cobol extends Tree {
     @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @With
-    class CompilationUnit implements Cobol, SourceFile {
+    class CompilationUnit implements Cobol, CobolSourceFile {
 
         @EqualsAndHashCode.Include
         UUID id;
@@ -1050,6 +1050,10 @@ public interface Cobol extends Tree {
 
         @Nullable
         IndicatorArea indicatorArea;
+
+        // Replacements
+        // Lines
+        // Comments
 
         String word;
 
@@ -9705,7 +9709,7 @@ public interface Cobol extends Tree {
         @Value
         @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
         @With
-        public static class CopyBook implements Cobol, SourceFile {
+        public static class CopyBook implements Cobol, CobolSourceFile {
 
             @EqualsAndHashCode.Include
             UUID id;
@@ -9931,6 +9935,9 @@ public interface Cobol extends Tree {
             List<Cobol> cobols;
 
             Word dot;
+
+            @Nullable
+            Cobol.Preprocessor.CopyBook copyBook;
 
             @Override
             public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -103,31 +103,6 @@ public interface Cobol extends Tree {
     @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @With
-    class IndicatorArea implements Cobol {
-
-        @EqualsAndHashCode.Include
-        UUID id;
-
-        Space prefix;
-        Markers markers;
-        String indicator;
-
-        @Nullable
-        String continuationPrefix;
-
-        public String getContinuationPrefix() {
-            return continuationPrefix == null ? "" : continuationPrefix;
-        }
-
-        @Override
-        public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
-            return v.visitIndicatorArea(this, p);
-        }
-    }
-
-    @Value
-    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @With
     class Abbreviation implements Cobol {
 
         @EqualsAndHashCode.Include
@@ -3325,6 +3300,31 @@ public interface Cobol extends Tree {
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitInData(this, p);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class IndicatorArea implements Cobol {
+
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+        Markers markers;
+        String indicator;
+
+        @Nullable
+        String continuationPrefix;
+
+        public String getContinuationPrefix() {
+            return continuationPrefix == null ? "" : continuationPrefix;
+        }
+
+        @Override
+        public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
+            return v.visitIndicatorArea(this, p);
         }
     }
 
@@ -9700,8 +9700,57 @@ public interface Cobol extends Tree {
         }
     }
 
-    @SuppressWarnings("InnerClassMayBeStatic")
     class Preprocessor {
+
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class CopyBook implements Cobol, SourceFile {
+
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            Path sourcePath;
+
+            @Nullable
+            FileAttributes fileAttributes;
+
+            Space prefix;
+            Markers markers;
+
+            @Nullable // for backwards compatibility
+            @With(AccessLevel.PRIVATE)
+            String charsetName;
+
+            boolean charsetBomMarked;
+
+            @Nullable
+            Checksum checksum;
+
+            @Override
+            public Charset getCharset() {
+                return charsetName == null ? StandardCharsets.UTF_8 : Charset.forName(charsetName);
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public SourceFile withCharset(Charset charset) {
+                return withCharsetName(charset.name());
+            }
+
+            Cobol ast;
+            Cobol.Word eof;
+
+            @Override
+            public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
+                return v.visitCopyBook(this, p);
+            }
+
+            @Override
+            public <P> TreeVisitor<?, PrintOutputCapture<P>> printer(Cursor cursor) {
+                return new CobolPrinter<>(true, true);
+            }
+        }
 
         @Value
         @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CobolPreprocessor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CobolPreprocessor.java
@@ -53,31 +53,6 @@ public interface CobolPreprocessor extends Tree {
     @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @With
-    class IndicatorArea implements CobolPreprocessor {
-
-        @EqualsAndHashCode.Include
-        UUID id;
-
-        Space prefix;
-        Markers markers;
-        String indicator;
-
-        @Nullable
-        String continuationPrefix;
-
-        public String getContinuationPrefix() {
-            return continuationPrefix == null ? "" : continuationPrefix;
-        }
-
-        @Override
-        public <P> CobolPreprocessor acceptCobolPreprocessor(CobolPreprocessorVisitor<P> v, P p) {
-            return v.visitIndicatorArea(this, p);
-        }
-    }
-
-    @Value
-    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @With
     class CharData implements CobolPreprocessor {
         @EqualsAndHashCode.Include
         UUID id;
@@ -275,7 +250,6 @@ public interface CobolPreprocessor extends Tree {
         }
     }
 
-    // TODO: CopyBook requires input from Jon/Sam on how to model as / or incorporate a SourceFile.
     @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @With
@@ -457,6 +431,31 @@ public interface CobolPreprocessor extends Tree {
         @Override
         public <P> CobolPreprocessor acceptCobolPreprocessor(CobolPreprocessorVisitor<P> v, P p) {
             return v.visitFamilyPhrase(this, p);
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class IndicatorArea implements CobolPreprocessor {
+
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        Space prefix;
+        Markers markers;
+        String indicator;
+
+        @Nullable
+        String continuationPrefix;
+
+        public String getContinuationPrefix() {
+            return continuationPrefix == null ? "" : continuationPrefix;
+        }
+
+        @Override
+        public <P> CobolPreprocessor acceptCobolPreprocessor(CobolPreprocessorVisitor<P> v, P p) {
+            return v.visitIndicatorArea(this, p);
         }
     }
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CobolSourceFile.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CobolSourceFile.java
@@ -1,0 +1,6 @@
+package org.openrewrite.cobol.tree;
+
+import org.openrewrite.SourceFile;
+
+public interface CobolSourceFile extends SourceFile {
+}

--- a/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/ParserAssertions.java
+++ b/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/ParserAssertions.java
@@ -229,15 +229,16 @@ public class ParserAssertions {
 
     public static Consumer<SourceSpec<Cobol.CompilationUnit>> isSerializable() {
         return spec -> spec.afterRecipe(cu -> {
-            try {
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                TreeSerializer serializer = new TreeSerializer();
-                serializer.write(singletonList(cu), bos);
-                InputStream is = new ByteArrayInputStream(bos.toByteArray());
-                serializer.read(is);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            // TODO: fix ... serialization issue due to dependencies.
+//            try {
+//                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+//                TreeSerializer serializer = new TreeSerializer();
+//                serializer.write(singletonList(cu), bos);
+//                InputStream is = new ByteArrayInputStream(bos.toByteArray());
+//                serializer.read(is);
+//            } catch (IOException e) {
+//                throw new RuntimeException(e);
+//            }
         });
     }
 }

--- a/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/ParserAssertions.java
+++ b/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/ParserAssertions.java
@@ -229,16 +229,15 @@ public class ParserAssertions {
 
     public static Consumer<SourceSpec<Cobol.CompilationUnit>> isSerializable() {
         return spec -> spec.afterRecipe(cu -> {
-            // TODO: fix ... serialization issue due to dependencies.
-//            try {
-//                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-//                TreeSerializer serializer = new TreeSerializer();
-//                serializer.write(singletonList(cu), bos);
-//                InputStream is = new ByteArrayInputStream(bos.toByteArray());
-//                serializer.read(is);
-//            } catch (IOException e) {
-//                throw new RuntimeException(e);
-//            }
+            try {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                TreeSerializer serializer = new TreeSerializer();
+                serializer.write(singletonList(cu), bos);
+                InputStream is = new ByteArrayInputStream(bos.toByteArray());
+                serializer.read(is);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         });
     }
 }


### PR DESCRIPTION
Changes:
- `CopyBook`s may be included as `Parser.Input`.
- `CopyBook` is retained on the `CopyStatement` to link the resolved `CopySource.`
- `CopyBook`s are converted from the `CobolPreprocessor` tree to the `Cobol` tree.

fixes #37