### PR TITLE
Replace line markers on cobol tree

### DIFF
--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolIsoVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolIsoVisitor.java
@@ -257,11 +257,6 @@ public class CobolIsoVisitor<P> extends CobolVisitor<P> {
     }
 
     @Override
-    public Cobol.CommentArea visitCommentArea(Cobol.CommentArea commentArea, P p) {
-        return (Cobol.CommentArea) super.visitCommentArea(commentArea, p);
-    }
-
-    @Override
     public Cobol.CommentEntry visitCommentEntry(Cobol.CommentEntry commentEntry, P p) {
         return (Cobol.CommentEntry) super.visitCommentEntry(commentEntry, p);
     }
@@ -769,11 +764,6 @@ public class CobolIsoVisitor<P> extends CobolVisitor<P> {
     @Override
     public Cobol.InData visitInData(Cobol.InData inData, P p) {
         return (Cobol.InData) super.visitInData(inData, p);
-    }
-
-    @Override
-    public Cobol.IndicatorArea visitIndicatorArea(Cobol.IndicatorArea indicatorArea, P p) {
-        return (Cobol.IndicatorArea) super.visitIndicatorArea(indicatorArea, p);
     }
 
     @Override
@@ -1972,11 +1962,6 @@ public class CobolIsoVisitor<P> extends CobolVisitor<P> {
     }
 
     @Override
-    public Cobol.SequenceArea visitSequenceArea(Cobol.SequenceArea sequenceArea, P p) {
-        return (Cobol.SequenceArea) super.visitSequenceArea(sequenceArea, p);
-    }
-
-    @Override
     public Cobol.Set visitSet(Cobol.Set set, P p) {
         return (Cobol.Set) super.visitSet(set, p);
     }
@@ -2299,6 +2284,22 @@ public class CobolIsoVisitor<P> extends CobolVisitor<P> {
     @Override
     public Cobol.WriteFromPhrase visitWriteFromPhrase(Cobol.WriteFromPhrase writeFromPhrase, P p) {
         return (Cobol.WriteFromPhrase) super.visitWriteFromPhrase(writeFromPhrase, p);
+    }
+
+    /* Cobol$ColumnArea visits */
+    @Override
+    public Cobol.ColumnArea.CommentArea visitCommentArea(Cobol.ColumnArea.CommentArea commentArea, P p) {
+        return (Cobol.ColumnArea.CommentArea) super.visitCommentArea(commentArea, p);
+    }
+
+    @Override
+    public Cobol.ColumnArea.IndicatorArea visitIndicatorArea(Cobol.ColumnArea.IndicatorArea indicatorArea, P p) {
+        return (Cobol.ColumnArea.IndicatorArea) super.visitIndicatorArea(indicatorArea, p);
+    }
+
+    @Override
+    public Cobol.ColumnArea.SequenceArea visitSequenceArea(Cobol.ColumnArea.SequenceArea sequenceArea, P p) {
+        return (Cobol.ColumnArea.SequenceArea) super.visitSequenceArea(sequenceArea, p);
     }
 
     /* Cobol$Preprocessor visits */

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolVisitor.java
@@ -489,14 +489,6 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         return c;
     }
 
-    public Cobol visitCommentArea(Cobol.CommentArea commentArea, P p) {
-        Cobol.CommentArea c = commentArea;
-        c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.COMMENT_AREA_PREFIX, p));
-        c = c.withMarkers(visitMarkers(c.getMarkers(), p));
-        c = c.withEndOfLine(visitSpace(c.getEndOfLine(), Space.Location.COMMENT_AREA_EOL, p));
-        return c;
-    }
-
     public Cobol visitCommentEntry(Cobol.CommentEntry commentEntry, P p) {
         Cobol.CommentEntry c = commentEntry;
         c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.COMMENT_ENTRY_PREFIX, p));
@@ -1474,13 +1466,6 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         i = i.withMarkers(visitMarkers(i.getMarkers(), p));
         i = i.withWord((Cobol.Word) visit(i.getWord(), p));
         i = i.withName((Name) visit(i.getName(), p));
-        return i;
-    }
-
-    public Cobol visitIndicatorArea(Cobol.IndicatorArea indicatorArea, P p) {
-        Cobol.IndicatorArea i = indicatorArea;
-        i = i.withPrefix(visitSpace(i.getPrefix(), Space.Location.INDICATOR_AREA_PREFIX, p));
-        i = i.withMarkers(visitMarkers(i.getMarkers(), p));
         return i;
     }
 
@@ -3747,13 +3732,6 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         return s;
     }
 
-    public Cobol visitSequenceArea(Cobol.SequenceArea sequenceArea, P p ) {
-        Cobol.SequenceArea s = sequenceArea;
-        s = s.withPrefix(visitSpace(s.getPrefix(), Space.Location.SEQUENCE_AREA_PREFIX, p));
-        s = s.withMarkers(visitMarkers(s.getMarkers(), p));
-        return s;
-    }
-
     public Cobol visitSet(Cobol.Set set, P p) {
         Cobol.Set s = set;
         s = s.withPrefix(visitSpace(s.getPrefix(), Space.Location.SET_PREFIX, p));
@@ -4323,9 +4301,9 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         Cobol.Word w = word;
         w = w.withPrefix(visitSpace(w.getPrefix(), Space.Location.WORD_PREFIX, p));
         w = w.withMarkers(visitMarkers(w.getMarkers(), p));
-        w = w.withSequenceArea((Cobol.SequenceArea) visit(w.getSequenceArea(), p));
-        w = w.withIndicatorArea((Cobol.IndicatorArea) visit(w.getIndicatorArea(), p));
-        w = w.withCommentArea((Cobol.CommentArea) visit(w.getCommentArea(), p));
+        w = w.withSequenceArea((Cobol.ColumnArea.SequenceArea) visit(w.getSequenceArea(), p));
+        w = w.withIndicatorArea((Cobol.ColumnArea.IndicatorArea) visit(w.getIndicatorArea(), p));
+        w = w.withCommentArea((Cobol.ColumnArea.CommentArea) visit(w.getCommentArea(), p));
         w = w.withCopyStatement((Cobol.Preprocessor.CopyStatement) visit(w.getCopyStatement(), p));
         return w;
     }
@@ -4397,6 +4375,29 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
         w = w.withFrom((Cobol.Word) visit(w.getFrom(), p));
         w = w.withName((Name) visit(w.getName(), p));
         return w;
+    }
+
+    /* Cobol$ColumnArea visits */
+    public Cobol visitCommentArea(Cobol.ColumnArea.CommentArea commentArea, P p) {
+        Cobol.ColumnArea.CommentArea c = commentArea;
+        c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.COMMENT_AREA_PREFIX, p));
+        c = c.withMarkers(visitMarkers(c.getMarkers(), p));
+        c = c.withEndOfLine(visitSpace(c.getEndOfLine(), Space.Location.COMMENT_AREA_EOL, p));
+        return c;
+    }
+
+    public Cobol visitIndicatorArea(Cobol.ColumnArea.IndicatorArea indicatorArea, P p) {
+        Cobol.ColumnArea.IndicatorArea i = indicatorArea;
+        i = i.withPrefix(visitSpace(i.getPrefix(), Space.Location.INDICATOR_AREA_PREFIX, p));
+        i = i.withMarkers(visitMarkers(i.getMarkers(), p));
+        return i;
+    }
+
+    public Cobol visitSequenceArea(Cobol.ColumnArea.SequenceArea sequenceArea, P p ) {
+        Cobol.ColumnArea.SequenceArea s = sequenceArea;
+        s = s.withPrefix(visitSpace(s.getPrefix(), Space.Location.SEQUENCE_AREA_PREFIX, p));
+        s = s.withMarkers(visitMarkers(s.getMarkers(), p));
+        return s;
     }
 
     /* Cobol$Preprocessor visits */

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/cleanup/RemoveWithDebuggingMode.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/cleanup/RemoveWithDebuggingMode.java
@@ -87,7 +87,7 @@ public class RemoveWithDebuggingMode extends Recipe {
                     if (isSafe) {
                         if (s.getComputerName().getCommentArea() != null && !s.getComputerName().getCommentArea().getPrefix().getWhitespace().isEmpty()) {
                             List<Cobol.Word> originalWords = s.getDebuggingMode();
-                            Cobol.CommentArea commentArea = s.getComputerName().getCommentArea();
+                            Cobol.ColumnArea.CommentArea commentArea = s.getComputerName().getCommentArea();
                             commentArea = commentArea.withPrefix(
                                     commentArea.getPrefix().withWhitespace(
                                             commentArea.getPrefix().getWhitespace().substring(1)));

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/format/ShiftSequenceAreas.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/format/ShiftSequenceAreas.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 @Value
 public class ShiftSequenceAreas extends CobolIsoVisitor<ExecutionContext> {
 
-    LinkedList<Cobol.SequenceArea> originalSequenceAreas;
+    LinkedList<Cobol.ColumnArea.SequenceArea> originalSequenceAreas;
     Cobol.Word startAfter;
 
     @NonFinal
@@ -36,7 +36,7 @@ public class ShiftSequenceAreas extends CobolIsoVisitor<ExecutionContext> {
     }
 
     @Override
-    public Cobol.SequenceArea visitSequenceArea(Cobol.SequenceArea sequenceArea, ExecutionContext executionContext) {
+    public Cobol.ColumnArea.SequenceArea visitSequenceArea(Cobol.ColumnArea.SequenceArea sequenceArea, ExecutionContext executionContext) {
         if (startShift) {
             originalSequenceAreas.add(sequenceArea);
             return originalSequenceAreas.removeFirst();

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -6000,9 +6000,9 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
             }
         }
 
-        Cobol.SequenceArea sequenceArea = null;
+        Cobol.ColumnArea.SequenceArea sequenceArea = null;
         if (sequenceAreaMarker != null) {
-            sequenceArea = new Cobol.SequenceArea(
+            sequenceArea = new Cobol.ColumnArea.SequenceArea(
                     randomId(),
                     Space.EMPTY,
                     Markers.EMPTY,
@@ -6011,9 +6011,9 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
             markers.remove(sequenceAreaMarker);
         }
 
-        Cobol.IndicatorArea indicatorArea = null;
+        Cobol.ColumnArea.IndicatorArea indicatorArea = null;
         if (indicatorAreaMarker != null) {
-            indicatorArea = new Cobol.IndicatorArea(
+            indicatorArea = new Cobol.ColumnArea.IndicatorArea(
                     randomId(),
                     Space.EMPTY,
                     Markers.EMPTY,
@@ -6023,9 +6023,9 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
             markers.remove(indicatorAreaMarker);
         }
 
-        Cobol.CommentArea commentArea = null;
+        Cobol.ColumnArea.CommentArea commentArea = null;
         if (commentAreaMarker != null) {
-            commentArea = new Cobol.CommentArea(
+            commentArea = new Cobol.ColumnArea.CommentArea(
                     randomId(),
                     commentAreaMarker.getPrefix(),
                     Markers.EMPTY,
@@ -7334,13 +7334,13 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                     word.getPrefix(),
                     word.getMarkers(),
                     word.getSequenceArea() == null ? null :
-                            new Cobol.SequenceArea(
+                            new Cobol.ColumnArea.SequenceArea(
                                     word.getSequenceArea().getId(),
                                     word.getSequenceArea().getPrefix(),
                                     word.getSequenceArea().getMarkers(),
                                     word.getSequenceArea().getSequence()),
                     word.getIndicatorArea() == null ? null :
-                            new Cobol.IndicatorArea(
+                            new Cobol.ColumnArea.IndicatorArea(
                                     word.getIndicatorArea().getId(),
                                     word.getIndicatorArea().getPrefix(),
                                     word.getIndicatorArea().getMarkers(),
@@ -7348,7 +7348,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                                     word.getIndicatorArea().getContinuationPrefix()),
                     word.getWord(),
                     word.getCommentArea() == null ? null :
-                            new Cobol.CommentArea(
+                            new Cobol.ColumnArea.CommentArea(
                                     word.getCommentArea().getId(),
                                     word.getCommentArea().getPrefix(),
                                     word.getCommentArea().getMarkers(),

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorParserVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorParserVisitor.java
@@ -33,11 +33,11 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.cobol.internal.CobolGrammarToken.COMMENT_ENTRY;
 import static org.openrewrite.cobol.internal.CobolGrammarToken.END_OF_FILE;
-import static org.openrewrite.cobol.tree.Space.format;
 
 public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor<Object> {
 
@@ -848,7 +848,7 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     private Space whitespace() {
         String prefix = source.substring(cursor, indexOfNextNonWhitespace(cursor, source));
         cursor += prefix.length();
-        return format(prefix);
+        return Space.build(prefix, emptyList());
     }
 
     private int indexOfNextNonWhitespace(int cursor, String source) {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
@@ -519,17 +519,6 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
     }
 
     @Override
-    public Cobol visitCommentArea(Cobol.CommentArea commentArea, PrintOutputCapture<P> p) {
-        beforeSyntax(commentArea, Space.Location.COMMENT_AREA_PREFIX, p);
-        if (printColumns) {
-            p.append(commentArea.getComment());
-        }
-        visitSpace(commentArea.getEndOfLine(), Space.Location.COMMENT_AREA_EOL, p);
-        afterSyntax(commentArea, p);
-        return commentArea;
-    }
-
-    @Override
     public Cobol visitCommentEntry(Cobol.CommentEntry commentEntry, PrintOutputCapture<P> p) {
         beforeSyntax(commentEntry, Space.Location.COMMENT_ENTRY_PREFIX, p);
         visit(commentEntry.getComments(), p);
@@ -1494,17 +1483,6 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visit(ifThen.getStatements(), p);
         afterSyntax(ifThen, p);
         return ifThen;
-    }
-
-    @Override
-    public Cobol visitIndicatorArea(Cobol.IndicatorArea indicatorArea, PrintOutputCapture<P> p) {
-        if (printColumns) {
-            beforeSyntax(indicatorArea, Space.Location.INDICATOR_AREA_PREFIX, p);
-            p.out.append(indicatorArea.getIndicator());
-            afterSyntax(indicatorArea, p);
-        }
-        p.out.append(indicatorArea.getContinuationPrefix());
-        return indicatorArea;
     }
 
     @Override
@@ -3722,16 +3700,6 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
     }
 
     @Override
-    public Cobol visitSequenceArea(Cobol.SequenceArea sequenceArea, PrintOutputCapture<P> p) {
-        if (printColumns) {
-            beforeSyntax(sequenceArea, Space.Location.SEQUENCE_AREA_PREFIX, p);
-            p.out.append(sequenceArea.getSequence());
-            afterSyntax(sequenceArea, p);
-        }
-        return sequenceArea;
-    }
-
-    @Override
     public Cobol visitSelectClause(Cobol.SelectClause selectClause, PrintOutputCapture<P> p) {
         beforeSyntax(selectClause, Space.Location.SEARCH_CLAUSE_PREFIX, p);
         visit(selectClause.getWords(), p);
@@ -4517,8 +4485,40 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         return writeFromPhrase;
     }
 
-    /* Cobol preprocessor visits */
+    /* Cobol$ColumnArea visits */
+    @Override
+    public Cobol visitCommentArea(Cobol.ColumnArea.CommentArea commentArea, PrintOutputCapture<P> p) {
+        beforeSyntax(commentArea, Space.Location.COMMENT_AREA_PREFIX, p);
+        if (printColumns) {
+            p.append(commentArea.getComment());
+        }
+        visitSpace(commentArea.getEndOfLine(), Space.Location.COMMENT_AREA_EOL, p);
+        afterSyntax(commentArea, p);
+        return commentArea;
+    }
 
+    @Override
+    public Cobol visitIndicatorArea(Cobol.ColumnArea.IndicatorArea indicatorArea, PrintOutputCapture<P> p) {
+        if (printColumns) {
+            beforeSyntax(indicatorArea, Space.Location.INDICATOR_AREA_PREFIX, p);
+            p.out.append(indicatorArea.getIndicator());
+            afterSyntax(indicatorArea, p);
+        }
+        p.out.append(indicatorArea.getContinuationPrefix());
+        return indicatorArea;
+    }
+
+    @Override
+    public Cobol visitSequenceArea(Cobol.ColumnArea.SequenceArea sequenceArea, PrintOutputCapture<P> p) {
+        if (printColumns) {
+            beforeSyntax(sequenceArea, Space.Location.SEQUENCE_AREA_PREFIX, p);
+            p.out.append(sequenceArea.getSequence());
+            afterSyntax(sequenceArea, p);
+        }
+        return sequenceArea;
+    }
+
+    /* Cobol$Preprocessor visits */
     @Override
     public Cobol visitCopyBook(Cobol.Preprocessor.CopyBook copyBook, PrintOutputCapture<P> p) {
         beforeSyntax(copyBook, Space.Location.COPY_BOOK_PREFIX, p);

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
@@ -4332,7 +4332,6 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         ReplaceOff replaceOff = null;
         Replace replace = null;
 
-        Lines lines = null;
         Continuation continuation = null;
 
         for (Marker marker : word.getMarkers().getMarkers()) {
@@ -4342,8 +4341,6 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
                 replaceOff = (ReplaceOff) marker;
             } else if (marker instanceof Replace) {
                 replace = (Replace) marker;
-            } else if (marker instanceof Lines) {
-                lines = (Lines) marker;
             } else if (marker instanceof Continuation) {
                 continuation = (Continuation) marker;
             }
@@ -4388,8 +4385,12 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
             return word;
         }
 
-        if (lines != null) {
-            visitLines(lines, p);
+
+        if (printColumns) {
+            for (CobolLine cobolLine : word.getPrefix().getCobolLines()) {
+                visitMarkers(cobolLine.getMarkers(), p);
+                cobolLine.printCobolLine(this, getCursor(), p);
+            }
         }
 
         if (continuation != null) {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/markers/Lines.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/markers/Lines.java
@@ -24,7 +24,10 @@ public class Lines implements Marker {
     @Value
     public static class Line {
         UUID id;
+
+        @Nullable
         SequenceArea sequenceArea;
+
         IndicatorArea indicatorArea;
         String content;
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/search/FindIndicators.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/search/FindIndicators.java
@@ -39,7 +39,7 @@ public class FindIndicators extends Recipe {
         }
 
         @Override
-        public Cobol.IndicatorArea visitIndicatorArea(Cobol.IndicatorArea indicatorArea, ExecutionContext executionContext) {
+        public Cobol.ColumnArea.IndicatorArea visitIndicatorArea(Cobol.ColumnArea.IndicatorArea indicatorArea, ExecutionContext executionContext) {
             if (indicator.equals(indicatorArea.getIndicator())) {
                 return SearchResult.found(indicatorArea);
             }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/BlankLine.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/BlankLine.java
@@ -1,0 +1,57 @@
+package org.openrewrite.cobol.tree;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.cobol.internal.CobolSourcePrinter;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.Markers;
+
+import java.util.function.UnaryOperator;
+
+@Value
+public class BlankLine implements CobolLine {
+
+    @With
+    Markers markers;
+
+    @Nullable
+    @With
+    Cobol.ColumnArea.SequenceArea sequenceArea;
+
+    @With
+    Cobol.ColumnArea.IndicatorArea indicatorArea;
+
+    @With
+    String contentArea;
+
+    @Nullable
+    @With
+    Cobol.ColumnArea.CommentArea commentArea;
+
+    @With
+    boolean isCopiedSource;
+
+    private static final UnaryOperator<String> COBOL_MARKER_WRAPPER =
+            out -> "~~" + out + (out.isEmpty() ? "" : "~~") + ">";
+
+    @Override
+    public <P> void printCobolLine(CobolSourcePrinter<P> sourcePrinter, Cursor cursor, PrintOutputCapture<P> p) {
+        for (Marker marker : markers.getMarkers()) {
+            p.out.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(cursor, this), COBOL_MARKER_WRAPPER));
+        }
+
+        if (!isCopiedSource) {
+            sourcePrinter.visit(sequenceArea, p);
+            sourcePrinter.visit(indicatorArea, p);
+            p.append(contentArea);
+            sourcePrinter.visit(commentArea, p);
+        }
+
+        for (Marker marker : markers.getMarkers()) {
+            p.out.append(p.getMarkerPrinter().afterSyntax(marker, new Cursor(cursor, this), COBOL_MARKER_WRAPPER));
+        }
+    }
+}

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -1046,10 +1046,10 @@ public interface Cobol extends Tree {
         Markers markers;
 
         @Nullable
-        SequenceArea sequenceArea;
+        ColumnArea.SequenceArea sequenceArea;
 
         @Nullable
-        IndicatorArea indicatorArea;
+        ColumnArea.IndicatorArea indicatorArea;
 
         // Replacements
         // Lines
@@ -1058,7 +1058,7 @@ public interface Cobol extends Tree {
         String word;
 
         @Nullable
-        CommentArea commentArea;
+        ColumnArea.CommentArea commentArea;
 
         @Nullable
         Preprocessor.CopyStatement copyStatement;
@@ -1152,26 +1152,6 @@ public interface Cobol extends Tree {
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitCombinableCondition(this, p);
-        }
-    }
-
-    @Value
-    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @With
-    class CommentArea implements Cobol {
-
-        @EqualsAndHashCode.Include
-        UUID id;
-
-        Space prefix;
-        Markers markers;
-        String comment;
-        Space endOfLine;
-        boolean isAdded;
-
-        @Override
-        public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
-            return v.visitCommentArea(this, p);
         }
     }
 
@@ -3304,31 +3284,6 @@ public interface Cobol extends Tree {
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitInData(this, p);
-        }
-    }
-
-    @Value
-    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @With
-    class IndicatorArea implements Cobol {
-
-        @EqualsAndHashCode.Include
-        UUID id;
-
-        Space prefix;
-        Markers markers;
-        String indicator;
-
-        @Nullable
-        String continuationPrefix;
-
-        public String getContinuationPrefix() {
-            return continuationPrefix == null ? "" : continuationPrefix;
-        }
-
-        @Override
-        public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
-            return v.visitIndicatorArea(this, p);
         }
     }
 
@@ -8300,24 +8255,6 @@ public interface Cobol extends Tree {
     @Value
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @With
-    class SequenceArea implements Cobol {
-
-        @EqualsAndHashCode.Include
-        UUID id;
-
-        Space prefix;
-        Markers markers;
-        String sequence;
-
-        @Override
-        public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
-            return v.visitSequenceArea(this, p);
-        }
-    }
-
-    @Value
-    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-    @With
     class Set implements Statement {
 
         @EqualsAndHashCode.Include
@@ -9701,6 +9638,72 @@ public interface Cobol extends Tree {
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
             return v.visitWriteFromPhrase(this, p);
+        }
+    }
+
+    class ColumnArea {
+
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class CommentArea implements Cobol {
+
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            Space prefix;
+            Markers markers;
+            String comment;
+            Space endOfLine;
+            boolean isAdded;
+
+            @Override
+            public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
+                return v.visitCommentArea(this, p);
+            }
+        }
+
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class IndicatorArea implements Cobol {
+
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            Space prefix;
+            Markers markers;
+            String indicator;
+
+            @Nullable
+            String continuationPrefix;
+
+            public String getContinuationPrefix() {
+                return continuationPrefix == null ? "" : continuationPrefix;
+            }
+
+            @Override
+            public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
+                return v.visitIndicatorArea(this, p);
+            }
+        }
+
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class SequenceArea implements Cobol {
+
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            Space prefix;
+            Markers markers;
+            String sequence;
+
+            @Override
+            public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
+                return v.visitSequenceArea(this, p);
+            }
         }
     }
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -9745,7 +9745,10 @@ public interface Cobol extends Tree {
                 return withCharsetName(charset.name());
             }
 
+            @Nullable
             Cobol ast;
+
+            @Nullable
             Cobol.Word eof;
 
             @Override

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -1051,9 +1051,9 @@ public interface Cobol extends Tree {
         @Nullable
         ColumnArea.IndicatorArea indicatorArea;
 
+        // Add:
         // Replacements
-        // Lines
-        // Comments
+        // Continuations
 
         String word;
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CobolLine.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CobolLine.java
@@ -1,0 +1,40 @@
+package org.openrewrite.cobol.tree;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.cobol.internal.CobolSourcePrinter;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.Markers;
+
+/**
+ * There may be one or more comments and/or empty lines between any token via whitespace.
+ * The Lines Marker preserves the column areas for each of the lines that come before a COBOL word.
+ * <p>
+ * Line comments are indicated with a `*` (depends on dialect) in the indicator areas.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@c")
+public interface CobolLine {
+
+    Markers getMarkers();
+    <C extends CobolLine> C withMarkers(Markers markers);
+
+    @Nullable
+    Cobol.ColumnArea.SequenceArea getSequenceArea();
+    <C extends CobolLine> C withSequenceArea(Cobol.ColumnArea.SequenceArea sequenceArea);
+
+    Cobol.ColumnArea.IndicatorArea getIndicatorArea();
+    <C extends CobolLine> C withIndicatorArea(Cobol.ColumnArea.IndicatorArea indicatorArea);
+
+    String getContentArea();
+    <C extends CobolLine> C withContentArea(String contentArea);
+
+    @Nullable
+    Cobol.ColumnArea.CommentArea getCommentArea();
+    <C extends CobolLine> C withCommentArea(Cobol.ColumnArea.CommentArea commentArea);
+
+    boolean isCopiedSource();
+    <C extends CobolLine> C withCopiedSource(boolean isCopiedSource);
+
+    <P> void printCobolLine(CobolSourcePrinter<P> sourcePrinter, Cursor cursor, PrintOutputCapture<P> p);
+}

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Comment.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Comment.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2022 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.openrewrite.cobol.tree;
 
 public interface Comment {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CommentLine.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CommentLine.java
@@ -1,0 +1,57 @@
+package org.openrewrite.cobol.tree;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Cursor;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.cobol.internal.CobolSourcePrinter;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.marker.Markers;
+
+import java.util.function.UnaryOperator;
+
+@Value
+public class CommentLine implements CobolLine, Comment {
+
+    @With
+    Markers markers;
+
+    @Nullable
+    @With
+    Cobol.ColumnArea.SequenceArea sequenceArea;
+
+    @With
+    Cobol.ColumnArea.IndicatorArea indicatorArea;
+
+    @With
+    String contentArea;
+
+    @Nullable
+    @With
+    Cobol.ColumnArea.CommentArea commentArea;
+
+    @With
+    boolean isCopiedSource;
+
+    private static final UnaryOperator<String> COBOL_MARKER_WRAPPER =
+            out -> "~~" + out + (out.isEmpty() ? "" : "~~") + ">";
+
+    @Override
+    public <P> void printCobolLine(CobolSourcePrinter<P> sourcePrinter, Cursor cursor, PrintOutputCapture<P> p) {
+        for (Marker marker : markers.getMarkers()) {
+            p.out.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(cursor, this), COBOL_MARKER_WRAPPER));
+        }
+
+        if (!isCopiedSource) {
+            sourcePrinter.visit(sequenceArea, p);
+            sourcePrinter.visit(indicatorArea, p);
+            p.append(contentArea);
+            sourcePrinter.visit(commentArea, p);
+        }
+
+        for (Marker marker : markers.getMarkers()) {
+            p.out.append(p.getMarkerPrinter().afterSyntax(marker, new Cursor(cursor, this), COBOL_MARKER_WRAPPER));
+        }
+    }
+}

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Space.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Space.java
@@ -133,6 +133,7 @@ public class Space {
         INDICATOR_AREA_PREFIX,
         COMMENT_AREA_PREFIX,
         COMMENT_AREA_EOL,
+        // Cobol preprocessor prefixes
         CONTINUATION_PREFIX,
         COMPILER_OPTION_PREFIX,
         COMPILER_OPTIONS_PREFIX,
@@ -154,7 +155,6 @@ public class Space {
         TITLE_STATEMENT_PREFIX,
         PREPROCESSOR_COMPILATION_UNIT_PREFIX,
         PREPROCESSOR_WORD_PREFIX,
-        // Cobol preprocessor prefixes
         CHAR_DATA_PREFIX,
         CHAR_DATA_LINE_PREFIX,
         CHAR_DATA_SQL_PREFIX,


### PR DESCRIPTION
Changes:

- Moved column area tree elements into `Cobol$ColumnArea`.
- `CopyBook#ast` and` CopyBook#eof` are nullable.
    - The SourceFile will contain the AST and EOF, but the `CopyBook` stored on the `CopyStatement` as metadata will contain a null AST and EOF.
- Replaced Lines markers on the `Cobol` tree with LST elements.

fixes #33