### PR TITLE
Convert reductive and additive types

### DIFF
--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolVisitor.java
@@ -4616,12 +4616,11 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
     }
 
     /* Cobol$Preprocessor$Replace */
-    public Cobol visitEqualReplacement(Cobol.Preprocessor.EqualReplacement equalReplacement, P p) {
-        Cobol.Preprocessor.EqualReplacement e = equalReplacement;
-        // A replacement does not contain a prefix.
-        e = e.withMarkers(visitMarkers(e.getMarkers(), p));
-        e = e.withOriginal((Cobol.Word) visit(e.getOriginal(), p));
-        return e;
+    public Cobol visitReplacement(Cobol.Preprocessor.Replacement replacement, P p) {
+        Cobol.Preprocessor.Replacement r = replacement;
+        r = r.withOriginalWords(ListUtils.map(r.getOriginalWords(), it ->
+                it.withOriginal((Cobol.Word) visit(it.getOriginal(), p))));
+        return r;
     }
 
     /* Misc visits */

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/PreprocessReplaceVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/PreprocessReplaceVisitor.java
@@ -132,7 +132,7 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
         private final ReplacementType replacementType;
 
         private List<CobolPreprocessor.Word> current;
-        private List<Replace> reductiveReplaces;
+        private ReplaceReductiveType replaceReductiveType = null;
         private int fromPos = 0;
         private int toPos = 0;
         boolean inMatch = false;
@@ -216,6 +216,7 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                 }
             } else if (ReplacementType.REDUCTIVE == replacementType) {
                 if (!inMatch) {
+                    replaceReductiveType = new ReplaceReductiveType(randomId(), new ArrayList<>());
                     if (from.containsKey(word)) {
                         inMatch = true;
                         current = from.get(word);
@@ -228,15 +229,13 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                             boolean isEmpty = toWord.getWord().isEmpty();
                             Replace replace = new Replace(randomId(), word, isEmpty);
                             if (isEmpty) {
-                                reductiveReplaces.add(replace);
-                                ReplaceReductiveType replaceReductiveType = new ReplaceReductiveType(randomId(), reductiveReplaces);
+                                replaceReductiveType.getOriginalWords().add(replace);
                                 word = word.withMarkers(word.getMarkers().addIfAbsent(replaceReductiveType));
                                 word = word.withWord(CobolPrinterUtils.fillArea(' ', word.getWord().length()));
                             } else {
                                 word = word.withMarkers(word.getMarkers().addIfAbsent(replace));
                                 word = word.withWord(toWord.getWord());
                             }
-
                         }
                         fromPos++;
                         toPos++;
@@ -246,8 +245,7 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                     if (isSame) {
                         if (toPos >= to.size()) {
                             Replace replace = new Replace(randomId(), word, true);
-                            reductiveReplaces.add(replace);
-                            ReplaceReductiveType replaceReductiveType = new ReplaceReductiveType(randomId(), reductiveReplaces);
+                            replaceReductiveType.getOriginalWords().add(replace);
                             word = word.withMarkers(word.getMarkers().addIfAbsent(replaceReductiveType));
                             word = word.withWord(CobolPrinterUtils.fillArea(' ', word.getWord().length()));
                         }
@@ -258,8 +256,7 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                             boolean isEmpty = toWord.getWord().isEmpty();
                             Replace replace = new Replace(randomId(), word, isEmpty);
                             if (isEmpty) {
-                                reductiveReplaces.add(replace);
-                                ReplaceReductiveType replaceReductiveType = new ReplaceReductiveType(randomId(), reductiveReplaces);
+                                replaceReductiveType.getOriginalWords().add(replace);
                                 word = word.withMarkers(word.getMarkers().addIfAbsent(replaceReductiveType));
                                 word = word.withWord(CobolPrinterUtils.fillArea(' ', word.getWord().length()));
                             } else {
@@ -273,7 +270,7 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                             current = null;
                             fromPos = 0;
                             toPos = 0;
-                            reductiveReplaces = new ArrayList<>();
+                            replaceReductiveType = null;
                         } else {
                             fromPos++;
                             toPos++;
@@ -366,7 +363,6 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                 } else if (words.size() < to.size()) {
                     return ReplacementType.ADDITIVE;
                 } else if (words.size() > from.size()) {
-                    reductiveReplaces = new ArrayList<>();
                     return ReplacementType.REDUCTIVE;
                 }
             }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorOutputSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorOutputSourcePrinter.java
@@ -266,6 +266,11 @@ public class CobolPreprocessorOutputSourcePrinter<P> extends CobolPreprocessorSo
                     for (Replace additionalWord : replaceAdditiveType.getAdditionalWords()) {
                         visit(additionalWord.getOriginalWord(), p);
                     }
+                    int curIndex = getCurrentIndex(p.getOut());
+                    int contentEnd = cobolDialect.getColumns().getOtherArea();
+                    int untilEndOfLine = curIndex >= contentEnd ? 0 : cobolDialect.getColumns().getOtherArea() - curIndex;
+                    String whitespace = generateWhitespace(untilEndOfLine) + "\n";
+                    p.append(whitespace);
                 }
 
                 visitSpace(word.getPrefix(), Space.Location.WORD_PREFIX, p);

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPrinter.java
@@ -29,6 +29,7 @@ public class CobolPrinter<P> extends CobolSourcePrinter<P> {
 
     private final boolean printColumns;
     private final boolean printOriginalSource;
+    private Cobol.Preprocessor.Replacement additiveReplacement = null;
 
     public CobolPrinter(boolean printColumns,
                         boolean printOriginalSource) {
@@ -51,6 +52,16 @@ public class CobolPrinter<P> extends CobolSourcePrinter<P> {
                 visitMarkers(cobolLine.getMarkers(), p);
                 cobolLine.printCobolLine(this, getCursor(), p);
             }
+        }
+
+        if (additiveReplacement == null && word.getReplacement() != null && word.getReplacement().getType() == Cobol.Preprocessor.Replacement.Type.ADDITIVE) {
+            additiveReplacement = word.getReplacement();
+        } else if (additiveReplacement != null && word.getReplacement() != null && word.getReplacement().getType() == Cobol.Preprocessor.Replacement.Type.ADDITIVE && additiveReplacement.getId() != word.getReplacement().getId()) {
+            additiveReplacement = word.getReplacement();
+            p.append("\n");
+        } else if (additiveReplacement != null && word.getReplacement() == null) {
+            additiveReplacement = null;
+            p.append("\n");
         }
 
         Optional<Continuation> continuation = word.getMarkers().findFirst(Continuation.class);

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
@@ -47,11 +47,13 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
     private final boolean printColumns;
 
     private final Collection<String> printedCopyStatements;
+    private final Collection<String> printedReductiveReplaces;
 
 
     public CobolSourcePrinter(boolean printColumns) {
         this.printColumns = printColumns;
         this.printedCopyStatements = new HashSet<>();
+        this.printedReductiveReplaces = new HashSet<>();
     }
 
     @Override
@@ -4384,16 +4386,27 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
             }
         }
 
-        if (word.getReplace() != null && word.getCopyStatement() == null) {
-            if (word.getReplace() instanceof Cobol.Preprocessor.EqualReplacement) {
-                Cobol.Preprocessor.EqualReplacement equalReplacement = (Cobol.Preprocessor.EqualReplacement) word.getReplace();
+        if (word.getReplacement() != null && word.getCopyStatement() == null) {
+            if (word.getReplacement().getType() == Cobol.Preprocessor.Replacement.Type.EQUAL) {
                 int startLength = p.getOut().length();
-                visit(equalReplacement, p);
+                Cobol.Preprocessor.Replacement.OriginalWord originalWord = word.getReplacement().getOriginalWords().get(0);
+                visit(originalWord.getOriginal(), p);
                 int endLength = p.getOut().length();
-                if (equalReplacement.isReplacedWithEmpty()) {
+                if (originalWord.isReplacedWithEmpty()) {
                     originalReplaceLength = endLength - startLength;
                 } else {
                     originalReplaceLength = 0;
+                    return word;
+                }
+            } else if (word.getReplacement().getType() == Cobol.Preprocessor.Replacement.Type.REDUCTIVE) {
+                if (printedReductiveReplaces.add(word.getReplacement().getId().toString())) {
+                    for (Cobol.Preprocessor.Replacement.OriginalWord originalWord : word.getReplacement().getOriginalWords()) {
+                        visit(originalWord.getOriginal(), p);
+                    }
+                    visit(word.getSequenceArea(), p);
+                    visit(word.getIndicatorArea(), p);
+                    beforeSyntax(word, Space.Location.WORD_PREFIX, p);
+                    p.append(word.getWord());
                     return word;
                 }
             }
@@ -4438,9 +4451,9 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
             if (replace != null && replace.isReplacedWithEmpty()) {
                 p.append(StringUtils.repeat(" ", word.getPrefix().getWhitespace().length() - originalReplaceLength));
                 originalReplaceLength = 0;
-            } else if (word.getReplace() != null &&
-                    word.getReplace() instanceof Cobol.Preprocessor.EqualReplacement &&
-                    ((Cobol.Preprocessor.EqualReplacement) word.getReplace()).isReplacedWithEmpty()) {
+            } else if (word.getReplacement() != null &&
+                    word.getReplacement().getType() == Cobol.Preprocessor.Replacement.Type.EQUAL &&
+                    word.getReplacement().getOriginalWords().get(0).isReplacedWithEmpty()) {
                 p.append(StringUtils.repeat(" ", word.getPrefix().getWhitespace().length() - originalReplaceLength));
                 originalReplaceLength = 0;
             } else {
@@ -4760,14 +4773,6 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         visit(titleStatement.getDot(), p);
         afterSyntax(titleStatement, p);
         return titleStatement;
-    }
-
-    /* Cobol$Preprocessor$Replace */
-    @Override
-    public Cobol visitEqualReplacement(Cobol.Preprocessor.EqualReplacement equalReplacement, PrintOutputCapture<P> p) {
-        Cobol.Preprocessor.EqualReplacement e = equalReplacement;
-        e = e.withOriginal((Cobol.Word) visit(e.getOriginal(), p));
-        return e;
     }
 
     /* Misc */

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
@@ -4398,6 +4398,8 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
                     originalReplaceLength = 0;
                     return word;
                 }
+            } else if (word.getReplacement().getType() == Cobol.Preprocessor.Replacement.Type.ADDITIVE) {
+                return word;
             } else if (word.getReplacement().getType() == Cobol.Preprocessor.Replacement.Type.REDUCTIVE) {
                 if (printedReductiveReplaces.add(word.getReplacement().getId().toString())) {
                     for (Cobol.Preprocessor.Replacement.OriginalWord originalWord : word.getReplacement().getOriginalWords()) {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/markers/ReplaceReductiveType.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/markers/ReplaceReductiveType.java
@@ -12,13 +12,13 @@ import java.util.UUID;
  * This marker represents a REDUCTIVE {@link org.openrewrite.cobol.PreprocessReplaceVisitor.ReplaceVisitor.ReplacementType}.
  * A REDUCTIVE change will cause words to be set to replaced by whitespace, and are not printed by
  * {@link CobolPreprocessorOutputSourcePrinter}.
- *
+ * <p>
  * There may be multiple removed words that get associated to the next visible word, so a unique Marker is created.
- *
+ * <p>
  * I.E. PERFORM FAIL. => ""
  * Before:
  *  |000001| | PERFORM FAIL .            nextWord|
- *
+ * <p>
  * After:
  *  |000001| |                           nextWord|
  */

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -1074,7 +1074,7 @@ public interface Cobol extends Tree {
         Preprocessor.ReplaceOffStatement replaceOffStatement;
 
         @Nullable
-        Preprocessor.Replace replace;
+        Preprocessor.Replacement replacement;
 
         @Override
         public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
@@ -10241,7 +10241,7 @@ public interface Cobol extends Tree {
         @Value
         @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
         @With
-        public static class EqualReplacement implements Replace {
+        public static class Replacement implements Cobol {
 
             @EqualsAndHashCode.Include
             UUID id;
@@ -10249,12 +10249,26 @@ public interface Cobol extends Tree {
             Space prefix;
             Markers markers;
 
-            Word original;
-            boolean replacedWithEmpty;
+            List<OriginalWord> originalWords;
+            Type type;
+
+            @Value
+            @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+            @With
+            public static class OriginalWord {
+                Word original;
+                boolean replacedWithEmpty;
+            }
+
+            public enum Type {
+                ADDITIVE,
+                REDUCTIVE,
+                EQUAL
+            }
 
             @Override
             public <P> Cobol acceptCobol(CobolVisitor<P> v, P p) {
-                return v.visitEqualReplacement(this, p);
+                return v.visitReplacement(this, p);
             }
         }
 

--- a/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolParserReplaceTest.kt
+++ b/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolParserReplaceTest.kt
@@ -69,6 +69,27 @@ class CobolParserReplaceTest : CobolTest() {
         )
 
     @Test
+    fun additiveReplace() =
+        rewriteRun(
+            cobolCopy(getNistSource("ADDITIVE_REPLACE.CBL"),
+                """
+                IDENTIFICATION DIVISION.                                         
+                PROGRAM-ID. SM208A.                                              
+                ENVIRONMENT DIVISION.                                            
+                DATA DIVISION.                                                   
+                WORKING-STORAGE SECTION.                                         
+                01    B     PICTURE                 S9(                                             
+                7) COMP.
+                01  C     PICTURE XXBXX/XX.                                      
+                01  D     PICTURE X(7) VALUE "PICTURE".                          
+                01  WRK-XN-00001  PIC X.                                         
+                01  WRK-XN-00020  PIC X(20).                                     
+                01  WRK-XN-00322  PIC X(322).                                    
+                """.trimIndent()
+            )
+        )
+
+    @Test
     fun reductiveReplace() =
         rewriteRun(
             cobolCopy(getNistSource("REDUCTIVE_REPLACE.CBL"),

--- a/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolParserReplaceTest.kt
+++ b/rewrite-cobol/src/test/kotlin/org/openrewrite/cobol/tree/CobolParserReplaceTest.kt
@@ -68,6 +68,23 @@ class CobolParserReplaceTest : CobolTest() {
             cobolCopy(getNistSource("SM201A_TRAILING_SUB.CBL"), sm201A)
         )
 
+    @Test
+    fun reductiveReplace() =
+        rewriteRun(
+            cobolCopy(getNistSource("REDUCTIVE_REPLACE.CBL"),
+                """
+                IDENTIFICATION DIVISION.                                         
+                PROGRAM-ID. SM208A.                                              
+                ENVIRONMENT DIVISION.                                            
+                DATA DIVISION.                                                   
+                WORKING-STORAGE SECTION.                                         
+                02  B     PICTURE S9(7) COMP.                                    
+                03  C     PICTURE XXBXX/XX.                                      
+                01  D     PICTURE X(7) VALUE "PICTURE".                          
+                """.trimIndent()
+            )
+        )
+
     val sm201A =
         """
         IDENTIFICATION DIVISION.                                         

--- a/rewrite-cobol/src/test/resources/gov/nist/ADDITIVE_REPLACE.CBL
+++ b/rewrite-cobol/src/test/resources/gov/nist/ADDITIVE_REPLACE.CBL
@@ -1,0 +1,15 @@
+000100 IDENTIFICATION DIVISION.                                         SM2084.2
+000200 PROGRAM-ID. SM208A.                                              SM2084.2
+000300 REPLACE OFF.                                                     SM2084.2
+000400 ENVIRONMENT DIVISION.                                            SM2084.2
+000500 DATA DIVISION.                                                   SM2084.2
+000600 WORKING-STORAGE SECTION.                                         SM2084.2
+000700 REPLACE ==01  A     PICTURE X.== BY                              SM2084.2
+000800         ==01  B     PICTURE S9(7) COMP.==.                       SM2084.2
+000900 01  A     PICTURE X.                                             SM2084.2
+001000 01  C     PICTURE XXBXX/XX.                                      SM2084.2
+001100 REPLACE OFF.                                                     SM2084.2
+001200 01  D     PICTURE X(7) VALUE "PICTURE".                          SM2084.2
+001300 01  WRK-XN-00001  PIC X.                                         SM2084.2
+001400 01  WRK-XN-00020  PIC X(20).                                     SM2084.2
+001500 01  WRK-XN-00322  PIC X(322).                                    SM2084.2

--- a/rewrite-cobol/src/test/resources/gov/nist/REDUCTIVE_REPLACE.CBL
+++ b/rewrite-cobol/src/test/resources/gov/nist/REDUCTIVE_REPLACE.CBL
@@ -1,0 +1,12 @@
+000100 IDENTIFICATION DIVISION.                                         SM2084.2
+000200 PROGRAM-ID. SM208A.                                              SM2084.2
+000300 REPLACE OFF.                                                     SM2084.2
+000400 ENVIRONMENT DIVISION.                                            SM2084.2
+000500 DATA DIVISION.                                                   SM2084.2
+000600 WORKING-STORAGE SECTION.                                         SM2084.2
+000700 REPLACE ==01  A     PICTURE X.== BY ==                    ==.    SM2084.2
+000800 01  A     PICTURE X.                                             SM2084.2
+000900 02  B     PICTURE S9(7) COMP.                                    SM2084.2
+001000 03  C     PICTURE XXBXX/XX.                                      SM2084.2
+001100 REPLACE OFF.                                                     SM2084.2
+001200 01  D     PICTURE X(7) VALUE "PICTURE".                          SM2084.2


### PR DESCRIPTION
Changes:
- Updated model for preserving pre-compilation replacement operations.
- Added support for printing additive and reductive replacements on source code through REPLACE AREA.

fixes #50