### PR TITLE
Added relationships for EXEC SQL CRUD operations.

### DIFF
--- a/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
@@ -20,6 +20,7 @@ import org.openrewrite.text.PlainTextVisitor;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -42,6 +43,8 @@ public class FindRelationships extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        final Set<String> seenCopies = new HashSet<>();
+        final Set<String> seenTables = new HashSet<>();
 
         /*
          * Find relationships from CopyBooks.
@@ -59,59 +62,73 @@ public class FindRelationships extends Recipe {
             @Override
             public CobolPreprocessor.CharDataSql visitCharDataSql(CobolPreprocessor.CharDataSql charDataSql, ExecutionContext ctx) {
                 CobolPreprocessor.CharDataSql sql = super.visitCharDataSql(charDataSql, ctx);
-                sql = getSqlRelationships(sql, sourceName, COPYBOOK, ctx);
-
-                return sql;
+                return getSqlRelationships(sql, sourceName, COPYBOOK, ctx);
             }
 
-            public CobolPreprocessor.CharDataSql getSqlRelationships(CobolPreprocessor.CharDataSql sql, String sourceName, CobolRelationships.ResourceType dependentType, ExecutionContext ctx) {
+            public CobolPreprocessor.CharDataSql getSqlRelationships(CobolPreprocessor.CharDataSql sql,
+                                                                     String sourceName,
+                                                                     CobolRelationships.ResourceType dependentType,
+                                                                     ExecutionContext ctx) {
                 return sql.withCobols(ListUtils.map(sql.getCobols(), (i, c) -> {
                     if (c instanceof CobolPreprocessor.CharDataLine) {
                         CobolPreprocessor.CharDataLine line = (CobolPreprocessor.CharDataLine) c;
                         if (line.getWords().size() >= 4 &&
                                 line.getWords().get(0) instanceof CobolPreprocessor.Word &&
-                                "declare".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
-                            return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
-                                if (j == 1 && w instanceof CobolPreprocessor.Word) {
-                                    String tableName = ((CobolPreprocessor.Word) w).getCobolWord().getWord();
-                                    if (line.getWords().get(2) instanceof CobolPreprocessor.Word &&
-                                            "cursor".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(2)).getCobolWord().getWord())) {
+                                "declare".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord()) &&
+                                line.getWords().get(2) instanceof CobolPreprocessor.Word) {
+                            if ("table".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(2)).getCobolWord().getWord())) {
+                                return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
+                                    if (j == 1 && w instanceof CobolPreprocessor.Word) {
                                         cobolRelationships.insertRow(ctx,
                                                 new CobolRelationships.Row(
                                                         sourceName,
                                                         dependentType,
-                                                        DECLARE,
-                                                        tableName,
-                                                        SQL_CURSOR,
-                                                        false));
-                                    } else {
-                                        cobolRelationships.insertRow(ctx,
-                                                new CobolRelationships.Row(
-                                                        sourceName,
-                                                        dependentType,
-                                                        DECLARE,
-                                                        tableName,
+                                                        CREATE,
+                                                        ((CobolPreprocessor.Word) w).getCobolWord().getWord(),
                                                         SQL_TABLE,
-                                                        false));
+                                                        false,
+                                                        ""));
+                                        return SearchResult.found(w);
                                     }
-                                    return SearchResult.found(w);
-                                }
-                                return w;
-                            }));
+                                    return w;
+                                }));
+                            } else if ("cursor".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(2)).getCobolWord().getWord())) {
+                                AtomicBoolean from = new AtomicBoolean(false);
+                                return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
+                                    if (w instanceof CobolPreprocessor.Word) {
+                                        if ("from".equalsIgnoreCase(((CobolPreprocessor.Word) w).getCobolWord().getWord())) {
+                                            from.set(true);
+                                        } else if (from.get()) {
+                                            cobolRelationships.insertRow(ctx,
+                                                    new CobolRelationships.Row(
+                                                            sourceName,
+                                                            dependentType,
+                                                            CREATE,
+                                                            ((CobolPreprocessor.Word) line.getWords().get(1)).getCobolWord().getWord(),
+                                                            SQL_CURSOR,
+                                                            false,
+                                                            ((CobolPreprocessor.Word) w).getCobolWord().getWord()));
+                                            from.set(false);
+                                            return SearchResult.found(w);
+                                        }
+                                    }
+                                    return w;
+                                }));
+                            }
                         } else if (line.getWords().size() >= 2 &&
                                 line.getWords().get(0) instanceof CobolPreprocessor.Word &&
                                 "include".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
                             return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
                                 if (j == 1 && w instanceof CobolPreprocessor.Word) {
-                                    String tableName = ((CobolPreprocessor.Word) w).getCobolWord().getWord();
                                     cobolRelationships.insertRow(ctx,
                                             new CobolRelationships.Row(
                                                     sourceName,
                                                     dependentType,
                                                     INCLUDE,
-                                                    tableName,
-                                                    SQL_TABLE,
-                                                    false));
+                                                    ((CobolPreprocessor.Word) w).getCobolWord().getWord(),
+                                                    COPYBOOK,
+                                                    false,
+                                                    ""));
                                     return SearchResult.found(w);
                                 }
                                 return w;
@@ -127,7 +144,6 @@ public class FindRelationships extends Recipe {
 
         CobolIsoVisitor<ExecutionContext> cobolVisitor = new CobolIsoVisitor<ExecutionContext>() {
             final Set<String> seenCalls = new HashSet<>();
-            final Set<String> seenCopies = new HashSet<>();
 
             String programName = "UNKNOWN";
 
@@ -155,7 +171,8 @@ public class FindRelationships extends Recipe {
                                             COPY,
                                             copyStatement.getCopySource().getName().getCobolWord().getWord(),
                                             COPYBOOK,
-                                            copyStatement.getMarkers().findFirst(MissingCopybook.class).isPresent()));
+                                            copyStatement.getMarkers().findFirst(MissingCopybook.class).isPresent(),
+                                            ""));
                         }
                         return copyStatement.withCopySource(copyStatement.getCopySource().withName(
                                 SearchResult.found(copyStatement.getCopySource().getName())));
@@ -187,7 +204,8 @@ public class FindRelationships extends Recipe {
                                             CALL,
                                             word.getWord().replace("\"", ""),
                                             COBOL,
-                                            false
+                                            false,
+                                            ""
                                     )
                             );
                         }
@@ -213,7 +231,8 @@ public class FindRelationships extends Recipe {
                                     INCLUDE,
                                     programName,
                                     COBOL,
-                                    false));
+                                    false,
+                                    ""));
                 }
                 return pt;
             }
@@ -237,7 +256,8 @@ public class FindRelationships extends Recipe {
                                         PLAN,
                                         linkedit,
                                         LINKEDIT,
-                                        false));
+                                        false,
+                                        ""));
                     } else {
                         Matcher memberMatcher = memberPattern.matcher(text);
                         while(memberMatcher.find()) {
@@ -249,7 +269,8 @@ public class FindRelationships extends Recipe {
                                             MEMBER,
                                             member,
                                             COBOL,
-                                            false));
+                                            false,
+                                            ""));
                         }
                     }
                 }

--- a/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
@@ -77,42 +77,25 @@ public class FindRelationships extends Recipe {
                         return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
                             if (w instanceof CobolPreprocessor.Word) {
                                 CobolPreprocessor.Word word = (CobolPreprocessor.Word) w;
-                                if (j == 1 && line.getWords().get(0) instanceof CobolPreprocessor.Word) {
-                                    if ("include".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
-                                        String copybookName = word.getCobolWord().getWord();
-                                        if (seenIncludes.add(copybookName)) {
-                                            cobolRelationships.insertRow(ctx,
-                                                    new CobolRelationships.Row(
-                                                            sourceName,
-                                                            dependentType,
-                                                            INCLUDE,
-                                                            copybookName,
-                                                            COPYBOOK,
-                                                            false,
-                                                            ""));
-                                            return SearchResult.found(word);
-                                        }
-                                    } else if ("update".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
-                                        String tableName = word.getCobolWord().getWord();
-                                        if (seenTableAccess.add(tableName + "_UPDATE")) {
-                                            cobolRelationships.insertRow(ctx,
-                                                    new CobolRelationships.Row(
-                                                            sourceName,
-                                                            dependentType,
-                                                            ACCESS,
-                                                            tableName,
-                                                            SQL_TABLE,
-                                                            false,
-                                                            "UPDATE"));
-                                            return SearchResult.found(word);
-                                        }
+                                if (j == 1 && line.getWords().get(0) instanceof CobolPreprocessor.Word &&
+                                        "include".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
+                                    String copybookName = word.getCobolWord().getWord();
+                                    if (seenIncludes.add(copybookName)) {
+                                        cobolRelationships.insertRow(ctx,
+                                                new CobolRelationships.Row(
+                                                        sourceName,
+                                                        dependentType,
+                                                        INCLUDE,
+                                                        copybookName,
+                                                        COPYBOOK,
+                                                        false,
+                                                        ""));
+                                        return SearchResult.found(word);
                                     }
-                                } else if ("from".equalsIgnoreCase(word.getCobolWord().getWord()) || "join".equalsIgnoreCase(word.getCobolWord().getWord())) {
-                                    tableNameNext.set(true);
-                                } else if (tableNameNext.get()) {
-                                    tableNameNext.set(false);
+                                } else if (j == 1 && line.getWords().get(0) instanceof CobolPreprocessor.Word &&
+                                        "update".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
                                     String tableName = word.getCobolWord().getWord();
-                                    if (seenTableAccess.add(tableName +  "_READ")) {
+                                    if (seenTableAccess.add(tableName + "_UPDATE")) {
                                         cobolRelationships.insertRow(ctx,
                                                 new CobolRelationships.Row(
                                                         sourceName,
@@ -121,7 +104,27 @@ public class FindRelationships extends Recipe {
                                                         tableName,
                                                         SQL_TABLE,
                                                         false,
-                                                        "READ"));
+                                                        "UPDATE"));
+                                        return SearchResult.found(word);
+                                    }
+                                } else if ("from".equalsIgnoreCase(word.getCobolWord().getWord()) || "join".equalsIgnoreCase(word.getCobolWord().getWord())) {
+                                    tableNameNext.set(true);
+                                } else if (tableNameNext.get()) {
+                                    tableNameNext.set(false);
+                                    String metadata = j - 2 >= 0 && line.getWords().get(j - 2) instanceof CobolPreprocessor.Word &&
+                                            "delete".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(j - 2)).getCobolWord().getWord()) ?
+                                            "DELETE" : "READ";
+                                    String tableName = word.getCobolWord().getWord();
+                                    if (seenTableAccess.add(tableName + "_" + metadata)) {
+                                        cobolRelationships.insertRow(ctx,
+                                                new CobolRelationships.Row(
+                                                        sourceName,
+                                                        dependentType,
+                                                        ACCESS,
+                                                        tableName,
+                                                        SQL_TABLE,
+                                                        false,
+                                                        metadata));
                                         return SearchResult.found(word);
                                     }
                                 } else if ("table".equalsIgnoreCase(word.getCobolWord().getWord()) && j - 2 >= 0 &&
@@ -173,7 +176,7 @@ public class FindRelationships extends Recipe {
                     if (ps instanceof CobolPreprocessor.CopyStatement) {
                         CobolPreprocessor.CopyStatement copyStatement = (CobolPreprocessor.CopyStatement) ps;
                         String copyName = copyStatement.getCopySource().getName().getCobolWord().getWord();
-                        if(seenCopies.add(copyName)) {
+                        if (seenCopies.add(copyName)) {
                             cobolRelationships.insertRow(ctx,
                                     new CobolRelationships.Row(
                                             programName,
@@ -206,7 +209,7 @@ public class FindRelationships extends Recipe {
                     Cobol.Word word = (Cobol.Word) call.getIdentifier();
                     if (word.getWord().startsWith("\"")) {
                         String callName = word.getWord().replace("\"", "");
-                        if(seenCalls.add(callName)) {
+                        if (seenCalls.add(callName)) {
                             cobolRelationships.insertRow(ctx,
                                     new CobolRelationships.Row(
                                             programName,
@@ -228,11 +231,12 @@ public class FindRelationships extends Recipe {
 
         PlainTextVisitor<ExecutionContext> linkEditVisitor = new PlainTextVisitor<ExecutionContext>() {
             final Pattern includePattern = Pattern.compile("^INCLUDE\\s+(SYS|OBJ)LIB\\((?<include>[A-Z0-9]+)\\)", MULTILINE);
+
             @Override
             public PlainText visitText(PlainText pt, ExecutionContext ctx) {
                 String text = pt.getText();
                 Matcher m = includePattern.matcher(text);
-                while(m.find()) {
+                while (m.find()) {
                     String programName = m.group("include");
                     cobolRelationships.insertRow(ctx,
                             new CobolRelationships.Row(
@@ -251,13 +255,14 @@ public class FindRelationships extends Recipe {
         PlainTextVisitor<ExecutionContext> bindCardVisitor = new PlainTextVisitor<ExecutionContext>() {
             final Pattern bindPattern = Pattern.compile("^BIND\\s+(?<keyword>PACKAGE|PLAN)\\((?<linkedit>[A-Z0-9]+)\\)\\s+OWNER\\(([A-Z0-9]+)\\)", MULTILINE);
             final Pattern memberPattern = Pattern.compile("\\s+MEMBER\\((?<member>[A-Z0-9]+)\\)", MULTILINE);
+
             @Override
             public PlainText visitText(PlainText pt, ExecutionContext ctx) {
                 String text = pt.getText();
                 Matcher m = bindPattern.matcher(text);
-                if(m.find()) {
+                if (m.find()) {
                     String packageOrPlan = m.group("keyword");
-                    if("PLAN".equals(packageOrPlan)) {
+                    if ("PLAN".equals(packageOrPlan)) {
                         String linkedit = m.group("linkedit");
                         cobolRelationships.insertRow(ctx,
                                 new CobolRelationships.Row(
@@ -270,7 +275,7 @@ public class FindRelationships extends Recipe {
                                         ""));
                     } else {
                         Matcher memberMatcher = memberPattern.matcher(text);
-                        while(memberMatcher.find()) {
+                        while (memberMatcher.find()) {
                             String member = memberMatcher.group("member");
                             cobolRelationships.insertRow(ctx,
                                     new CobolRelationships.Row(
@@ -293,9 +298,9 @@ public class FindRelationships extends Recipe {
             public Tree preVisit(Tree tree, ExecutionContext ctx) {
                 stopAfterPreVisit();
                 Tree t = tree;
-                if(tree instanceof Cobol) {
+                if (tree instanceof Cobol) {
                     t = cobolVisitor.visit(t, ctx);
-                } else if(tree instanceof PlainText) {
+                } else if (tree instanceof PlainText) {
                     t = linkEditVisitor.visit(t, ctx);
                     t = bindCardVisitor.visit(t, ctx);
                 } else if (tree instanceof CobolPreprocessor) {

--- a/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
@@ -44,7 +44,9 @@ public class FindRelationships extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         final Set<String> seenCopies = new HashSet<>();
-        final Set<String> seenTables = new HashSet<>();
+        final Set<String> seenIncludes = new HashSet<>();
+        final Set<String> seenTableAccess = new HashSet<>();
+        final Set<String> seenTableCreate = new HashSet<>();
 
         /*
          * Find relationships from CopyBooks.
@@ -72,68 +74,62 @@ public class FindRelationships extends Recipe {
                 return sql.withCobols(ListUtils.map(sql.getCobols(), (i, c) -> {
                     if (c instanceof CobolPreprocessor.CharDataLine) {
                         CobolPreprocessor.CharDataLine line = (CobolPreprocessor.CharDataLine) c;
-                        if (line.getWords().size() >= 4 &&
-                                line.getWords().get(0) instanceof CobolPreprocessor.Word &&
-                                "declare".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord()) &&
-                                line.getWords().get(2) instanceof CobolPreprocessor.Word) {
-                            if ("table".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(2)).getCobolWord().getWord())) {
-                                return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
-                                    if (j == 1 && w instanceof CobolPreprocessor.Word) {
+                        AtomicBoolean tableNameNext = new AtomicBoolean(false);
+                        return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
+                            if (w instanceof CobolPreprocessor.Word) {
+                                CobolPreprocessor.Word word = (CobolPreprocessor.Word) w;
+                                if (j == 1 && line.getWords().get(0) instanceof CobolPreprocessor.Word &&
+                                        "include".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
+                                    String copybookName = word.getCobolWord().getWord();
+                                    if (seenIncludes.add(copybookName)) {
                                         cobolRelationships.insertRow(ctx,
                                                 new CobolRelationships.Row(
                                                         sourceName,
                                                         dependentType,
-                                                        CREATE,
-                                                        ((CobolPreprocessor.Word) w).getCobolWord().getWord(),
-                                                        SQL_TABLE,
+                                                        INCLUDE,
+                                                        copybookName,
+                                                        COPYBOOK,
                                                         false,
                                                         ""));
-                                        return SearchResult.found(w);
+                                        return SearchResult.found(word);
                                     }
-                                    return w;
-                                }));
-                            } else if ("cursor".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(2)).getCobolWord().getWord())) {
-                                AtomicBoolean from = new AtomicBoolean(false);
-                                return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
-                                    if (w instanceof CobolPreprocessor.Word) {
-                                        if ("from".equalsIgnoreCase(((CobolPreprocessor.Word) w).getCobolWord().getWord())) {
-                                            from.set(true);
-                                        } else if (from.get()) {
-                                            cobolRelationships.insertRow(ctx,
-                                                    new CobolRelationships.Row(
-                                                            sourceName,
-                                                            dependentType,
-                                                            CREATE,
-                                                            ((CobolPreprocessor.Word) line.getWords().get(1)).getCobolWord().getWord(),
-                                                            SQL_CURSOR,
-                                                            false,
-                                                            ((CobolPreprocessor.Word) w).getCobolWord().getWord()));
-                                            from.set(false);
-                                            return SearchResult.found(w);
-                                        }
+                                } else if ("from".equalsIgnoreCase(word.getCobolWord().getWord()) || "join".equalsIgnoreCase(word.getCobolWord().getWord())) {
+                                    tableNameNext.set(true);
+                                } else if (tableNameNext.get()) {
+                                    tableNameNext.set(false);
+                                    String tableName = word.getCobolWord().getWord();
+                                    if (seenTableAccess.add(tableName +  "_READ")) {
+                                        cobolRelationships.insertRow(ctx,
+                                                new CobolRelationships.Row(
+                                                        sourceName,
+                                                        dependentType,
+                                                        ACCESS,
+                                                        tableName,
+                                                        SQL_TABLE,
+                                                        false,
+                                                        "READ"));
+                                        return SearchResult.found(word);
                                     }
-                                    return w;
-                                }));
-                            }
-                        } else if (line.getWords().size() >= 2 &&
-                                line.getWords().get(0) instanceof CobolPreprocessor.Word &&
-                                "include".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
-                            return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
-                                if (j == 1 && w instanceof CobolPreprocessor.Word) {
-                                    cobolRelationships.insertRow(ctx,
-                                            new CobolRelationships.Row(
-                                                    sourceName,
-                                                    dependentType,
-                                                    INCLUDE,
-                                                    ((CobolPreprocessor.Word) w).getCobolWord().getWord(),
-                                                    COPYBOOK,
-                                                    false,
-                                                    ""));
-                                    return SearchResult.found(w);
+                                } else if ("table".equalsIgnoreCase(word.getCobolWord().getWord()) && j - 2 >= 0 &&
+                                        line.getWords().get(j - 2) instanceof CobolPreprocessor.Word &&
+                                        "declare".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(j - 2)).getCobolWord().getWord())) {
+                                    CobolPreprocessor.Word tableName = (CobolPreprocessor.Word) line.getWords().get(j - 1);
+                                    if (seenTableCreate.add(tableName.getCobolWord().getWord() + "_CREATE")) {
+                                        cobolRelationships.insertRow(ctx,
+                                                new CobolRelationships.Row(
+                                                        sourceName,
+                                                        dependentType,
+                                                        ACCESS,
+                                                        tableName.getCobolWord().getWord(),
+                                                        SQL_TABLE,
+                                                        false,
+                                                        "CREATE"));
+                                        return SearchResult.found(word);
+                                    }
                                 }
-                                return w;
-                            }));
-                        }
+                            }
+                            return w;
+                        }));
                     }
                     return c;
                 }));

--- a/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
@@ -46,7 +46,6 @@ public class FindRelationships extends Recipe {
         final Set<String> seenCopies = new HashSet<>();
         final Set<String> seenIncludes = new HashSet<>();
         final Set<String> seenTableAccess = new HashSet<>();
-        final Set<String> seenTableCreate = new HashSet<>();
 
         /*
          * Find relationships from CopyBooks.
@@ -78,20 +77,35 @@ public class FindRelationships extends Recipe {
                         return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
                             if (w instanceof CobolPreprocessor.Word) {
                                 CobolPreprocessor.Word word = (CobolPreprocessor.Word) w;
-                                if (j == 1 && line.getWords().get(0) instanceof CobolPreprocessor.Word &&
-                                        "include".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
-                                    String copybookName = word.getCobolWord().getWord();
-                                    if (seenIncludes.add(copybookName)) {
-                                        cobolRelationships.insertRow(ctx,
-                                                new CobolRelationships.Row(
-                                                        sourceName,
-                                                        dependentType,
-                                                        INCLUDE,
-                                                        copybookName,
-                                                        COPYBOOK,
-                                                        false,
-                                                        ""));
-                                        return SearchResult.found(word);
+                                if (j == 1 && line.getWords().get(0) instanceof CobolPreprocessor.Word) {
+                                    if ("include".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
+                                        String copybookName = word.getCobolWord().getWord();
+                                        if (seenIncludes.add(copybookName)) {
+                                            cobolRelationships.insertRow(ctx,
+                                                    new CobolRelationships.Row(
+                                                            sourceName,
+                                                            dependentType,
+                                                            INCLUDE,
+                                                            copybookName,
+                                                            COPYBOOK,
+                                                            false,
+                                                            ""));
+                                            return SearchResult.found(word);
+                                        }
+                                    } else if ("update".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
+                                        String tableName = word.getCobolWord().getWord();
+                                        if (seenTableAccess.add(tableName + "_UPDATE")) {
+                                            cobolRelationships.insertRow(ctx,
+                                                    new CobolRelationships.Row(
+                                                            sourceName,
+                                                            dependentType,
+                                                            ACCESS,
+                                                            tableName,
+                                                            SQL_TABLE,
+                                                            false,
+                                                            "UPDATE"));
+                                            return SearchResult.found(word);
+                                        }
                                     }
                                 } else if ("from".equalsIgnoreCase(word.getCobolWord().getWord()) || "join".equalsIgnoreCase(word.getCobolWord().getWord())) {
                                     tableNameNext.set(true);
@@ -114,7 +128,7 @@ public class FindRelationships extends Recipe {
                                         line.getWords().get(j - 2) instanceof CobolPreprocessor.Word &&
                                         "declare".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(j - 2)).getCobolWord().getWord())) {
                                     CobolPreprocessor.Word tableName = (CobolPreprocessor.Word) line.getWords().get(j - 1);
-                                    if (seenTableCreate.add(tableName.getCobolWord().getWord() + "_CREATE")) {
+                                    if (seenTableAccess.add(tableName.getCobolWord().getWord() + "_CREATE")) {
                                         cobolRelationships.insertRow(ctx,
                                                 new CobolRelationships.Row(
                                                         sourceName,

--- a/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindRelationships.java
@@ -48,7 +48,7 @@ public class FindRelationships extends Recipe {
         final Set<String> seenTableAccess = new HashSet<>();
 
         /*
-         * Find relationships from CopyBooks.
+         * Find relationships from CobolPreprocessor tree.
          */
         class PreprocessorRelationshipVisitor extends CobolPreprocessorIsoVisitor<ExecutionContext> {
             String sourceName = "UNKNOWN";
@@ -77,9 +77,9 @@ public class FindRelationships extends Recipe {
                         return line.withWords(ListUtils.map(line.getWords(), (j, w) -> {
                             if (w instanceof CobolPreprocessor.Word) {
                                 CobolPreprocessor.Word word = (CobolPreprocessor.Word) w;
-                                if (j == 1 && line.getWords().get(0) instanceof CobolPreprocessor.Word &&
-                                        "include".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
-                                    String copybookName = word.getCobolWord().getWord();
+                                if ("include".equalsIgnoreCase(word.getCobolWord().getWord()) &&
+                                        j == 0 && 2 <= line.getWords().size() && line.getWords().get(1) instanceof CobolPreprocessor.Word) {
+                                    String copybookName = ((CobolPreprocessor.Word) line.getWords().get(1)).getCobolWord().getWord();
                                     if (seenIncludes.add(copybookName)) {
                                         cobolRelationships.insertRow(ctx,
                                                 new CobolRelationships.Row(
@@ -92,9 +92,9 @@ public class FindRelationships extends Recipe {
                                                         ""));
                                         return SearchResult.found(word);
                                     }
-                                } else if (j == 1 && line.getWords().get(0) instanceof CobolPreprocessor.Word &&
-                                        "update".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(0)).getCobolWord().getWord())) {
-                                    String tableName = word.getCobolWord().getWord();
+                                } else if ("update".equalsIgnoreCase(word.getCobolWord().getWord()) &&
+                                        j == 0 && 2 < line.getWords().size() && line.getWords().get(1) instanceof CobolPreprocessor.Word) {
+                                    String tableName = ((CobolPreprocessor.Word) line.getWords().get(1)).getCobolWord().getWord();
                                     if (seenTableAccess.add(tableName + "_UPDATE")) {
                                         cobolRelationships.insertRow(ctx,
                                                 new CobolRelationships.Row(
@@ -105,6 +105,21 @@ public class FindRelationships extends Recipe {
                                                         SQL_TABLE,
                                                         false,
                                                         "UPDATE"));
+                                        return SearchResult.found(word);
+                                    }
+                                }  else if ("insert".equalsIgnoreCase(word.getCobolWord().getWord()) &&
+                                        j == 0 && 3 < line.getWords().size() && line.getWords().get(2) instanceof CobolPreprocessor.Word) {
+                                    String tableName = ((CobolPreprocessor.Word) line.getWords().get(2)).getCobolWord().getWord();
+                                    if (seenTableAccess.add(tableName + "_INSERT")) {
+                                        cobolRelationships.insertRow(ctx,
+                                                new CobolRelationships.Row(
+                                                        sourceName,
+                                                        dependentType,
+                                                        ACCESS,
+                                                        tableName,
+                                                        SQL_TABLE,
+                                                        false,
+                                                        "INSERT"));
                                         return SearchResult.found(word);
                                     }
                                 } else if ("from".equalsIgnoreCase(word.getCobolWord().getWord()) || "join".equalsIgnoreCase(word.getCobolWord().getWord())) {
@@ -127,17 +142,18 @@ public class FindRelationships extends Recipe {
                                                         metadata));
                                         return SearchResult.found(word);
                                     }
-                                } else if ("table".equalsIgnoreCase(word.getCobolWord().getWord()) && j - 2 >= 0 &&
-                                        line.getWords().get(j - 2) instanceof CobolPreprocessor.Word &&
-                                        "declare".equalsIgnoreCase(((CobolPreprocessor.Word) line.getWords().get(j - 2)).getCobolWord().getWord())) {
-                                    CobolPreprocessor.Word tableName = (CobolPreprocessor.Word) line.getWords().get(j - 1);
-                                    if (seenTableAccess.add(tableName.getCobolWord().getWord() + "_CREATE")) {
+                                } else if ("declare".equalsIgnoreCase(word.getCobolWord().getWord()) &&
+                                        j + 2 < line.getWords().size() &&
+                                        line.getWords().get(j + 1) instanceof CobolPreprocessor.Word &&
+                                        line.getWords().get(j + 2) instanceof CobolPreprocessor.Word) {
+                                    String tableName = ((CobolPreprocessor.Word) line.getWords().get(j + 1)).getCobolWord().getWord();
+                                    if (seenTableAccess.add(tableName + "_CREATE")) {
                                         cobolRelationships.insertRow(ctx,
                                                 new CobolRelationships.Row(
                                                         sourceName,
                                                         dependentType,
                                                         ACCESS,
-                                                        tableName.getCobolWord().getWord(),
+                                                        tableName,
                                                         SQL_TABLE,
                                                         false,
                                                         "CREATE"));

--- a/src/main/java/org/openrewrite/cobol/table/CobolRelationships.java
+++ b/src/main/java/org/openrewrite/cobol/table/CobolRelationships.java
@@ -54,7 +54,6 @@ public class CobolRelationships extends DataTable<CobolRelationships.Row> {
         LINKEDIT,
         BINDPLAN,
         BINDPACKAGE,
-        SQL_CURSOR,
         SQL_TABLE
     }
 
@@ -71,10 +70,6 @@ public class CobolRelationships extends DataTable<CobolRelationships.Row> {
          * Program call
          */
         CALL,
-        /**
-         * An exec sql declare statement defines a DB2 table.
-         */
-        CREATE,
         /**
          * Link-Edit card includes COBOL program.
          * <p>

--- a/src/main/java/org/openrewrite/cobol/table/CobolRelationships.java
+++ b/src/main/java/org/openrewrite/cobol/table/CobolRelationships.java
@@ -43,9 +43,9 @@ public class CobolRelationships extends DataTable<CobolRelationships.Row> {
                 description = "Indicates whether the dependency is a known resource.")
         boolean dependencyMissing;
 
-        @Column(displayName = "Metadata",
+        @Column(displayName = "Action metadata",
                 description = "Additional data about the action.")
-        String metadata;
+        String actionMetadata;
     }
 
     public enum ResourceType {

--- a/src/main/java/org/openrewrite/cobol/table/CobolRelationships.java
+++ b/src/main/java/org/openrewrite/cobol/table/CobolRelationships.java
@@ -42,6 +42,10 @@ public class CobolRelationships extends DataTable<CobolRelationships.Row> {
         @Column(displayName = "Dependency missing",
                 description = "Indicates whether the dependency is a known resource.")
         boolean dependencyMissing;
+
+        @Column(displayName = "Metadata",
+                description = "Additional data about the action.")
+        String metadata;
     }
 
     public enum ResourceType {
@@ -56,6 +60,10 @@ public class CobolRelationships extends DataTable<CobolRelationships.Row> {
 
     public enum ResourceAction {
         /**
+         * A COBOL program accesses a DB2 table.
+         */
+        ACCESS,
+        /**
          * Copybook call
          */
         COPY,
@@ -64,13 +72,13 @@ public class CobolRelationships extends DataTable<CobolRelationships.Row> {
          */
         CALL,
         /**
-         * A EXEC SQL DECLARE statement creates a SQL table.
+         * An exec sql declare statement defines a DB2 table.
          */
-        DECLARE,
+        CREATE,
         /**
          * Link-Edit card includes COBOL program.
          * <p>
-         * A COBOL program includes a SQL table.
+         * A COBOL program includes a copybook through EXEC SQL INCLUDE.
          */
         INCLUDE,
         /**

--- a/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
+++ b/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
@@ -219,7 +219,7 @@ public class FindRelationshipsTest extends CobolTest {
             """
               000000 IDENTIFICATION DIVISION.
                      PROGRAM-ID.
-                         EXEC_SQL_READ.
+                         EXEC_SQL_UPDATE.
                      DATA DIVISION.
                      WORKING-STORAGE SECTION.
                      01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
@@ -249,6 +249,58 @@ public class FindRelationshipsTest extends CobolTest {
                          EXEC SQL
                             UPDATE PROD_TBL_02
                             SET NUM_1 = :DCL_PROD_TBL_02_NUM_1_CPY
+                         END-EXEC.
+              """,
+            spec -> spec.after(s -> s).path("DECLARE_TABLE_2.CPY")
+          )
+        );
+    }
+
+    @Test
+    void execSqlDelete() {
+        rewriteRun(
+          spec -> spec.dataTable(Row.class, rows -> {
+              assertThat(rows.stream().map(Row::getDependent)).contains("DECLARE_TABLE_2", "EXEC_SQL_DELETE");
+              assertThat(rows.stream().map(Row::getDependentType)).contains(COPYBOOK, COBOL);
+              assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
+              assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "PROD_TBL_02");
+              assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
+              assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "DELETE");
+          }),
+          cobol(
+            """
+              000000 IDENTIFICATION DIVISION.
+                     PROGRAM-ID.
+                         EXEC_SQL_DELETE.
+                     DATA DIVISION.
+                     WORKING-STORAGE SECTION.
+                     01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
+                     01 DCL_PROD_TBL_02_NUM_1 PIC X(3).
+              
+                    * Include SQL table from another COBOL source.
+                    * These SQL tables are created through copybooks.
+                     EXEC SQL INCLUDE DECLARE_TABLE_2 END-EXEC.
+
+                     EXEC SQL
+                         DELETE FROM PROD_TBL_02
+                         WHERE NUM_1 = :DCL_PROD_TBL_02_NUM_1
+                     END-EXEC.
+              """,
+            spec -> spec.after(s -> s).path("EXEC_SQL_DELETE.CBL")
+          ),
+          preprocessor(
+            """
+              000000*    EXEC SQL statement to declare a table
+                         EXEC SQL DECLARE PROD_TBL_02 TABLE
+                         ( NUM_1                  CHAR(3) NOT NULL,
+                           NUM_2                  CHAR(5) NOT NULL,
+                           CREATED_DATE           DATE NOT NULL
+                         ) END-EXEC.
+                         
+                         01 DCL_PROD_TBL_02_NUM_1_CPY PIC X(3).
+                         EXEC SQL
+                            DELETE FROM PROD_TBL_02
+                            WHERE NUM_1 = :DCL_PROD_TBL_02_NUM_1_CPY
                          END-EXEC.
               """,
             spec -> spec.after(s -> s).path("DECLARE_TABLE_2.CPY")

--- a/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
+++ b/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
@@ -80,7 +80,7 @@ public class FindRelationshipsTest extends CobolTest {
               assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
               assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "PROD_TBL_01", "PROD_TBL_02");
               assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
-              assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "READ");
+              assertThat(rows.stream().map(Row::getActionMetadata)).contains("CREATE", "READ");
           }),
           cobol(
             """
@@ -144,7 +144,7 @@ public class FindRelationshipsTest extends CobolTest {
               assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
               assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "PROD_TBL_02", "PROD_TBL_03");
               assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
-              assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "READ");
+              assertThat(rows.stream().map(Row::getActionMetadata)).contains("CREATE", "READ");
           }),
           cobol(
             """
@@ -178,8 +178,7 @@ public class FindRelationshipsTest extends CobolTest {
               000000*    EXEC SQL statement to declare a table
                          EXEC SQL DECLARE PROD_TBL_02 TABLE
                          ( NUM_1                  CHAR(3) NOT NULL,
-                           NUM_2                  CHAR(5) NOT NULL,
-                           CREATED_DATE           DATE NOT NULL
+                           NUM_2                  CHAR(5) NOT NULL
                          ) END-EXEC.
               """,
             spec -> spec.after(s -> s).path("DECLARE_TABLE_2.CPY")
@@ -189,8 +188,7 @@ public class FindRelationshipsTest extends CobolTest {
               000000*    EXEC SQL statement to declare a table
                          EXEC SQL DECLARE PROD_TBL_03 TABLE
                          ( NUM_1                  CHAR(3) NOT NULL,
-                           NUM_2                  CHAR(5) NOT NULL,
-                           CREATED_DATE           DATE NOT NULL
+                           NUM_2                  CHAR(5) NOT NULL
                          ) END-EXEC.
                      01 DCL_PROD_TBL_03_NUM_2 PIC X(3).
                      EXEC SQL
@@ -213,7 +211,7 @@ public class FindRelationshipsTest extends CobolTest {
               assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
               assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "PROD_TBL_02");
               assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
-              assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "UPDATE");
+              assertThat(rows.stream().map(Row::getActionMetadata)).contains("CREATE", "INSERT", "UPDATE");
           }),
           cobol(
             """
@@ -224,6 +222,7 @@ public class FindRelationshipsTest extends CobolTest {
                      WORKING-STORAGE SECTION.
                      01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
                      01 DCL_PROD_TBL_02_NUM_1 PIC X(3).
+                     01 DCL_PROD_TBL_02_NUM_2 PIC X(5).
               
                     * Include SQL table from another COBOL source.
                     * These SQL tables are created through copybooks.
@@ -233,6 +232,14 @@ public class FindRelationshipsTest extends CobolTest {
                          UPDATE PROD_TBL_02
                          SET NUM_1 = :DCL_PROD_TBL_02_NUM_1
                      END-EXEC.
+
+                     EXEC SQL
+                         INSERT INTO PROD_TBL_02
+                                (NUM_1,
+                                 NUM_2)
+                         VALUES (:DCL_PROD_TBL_02_NUM_1
+                                 :DCL_PROD_TBL_02_NUM_2)
+                     END-EXEC.
               """,
             spec -> spec.after(s -> s).path("EXEC_SQL_UPDATE.CBL")
           ),
@@ -241,8 +248,7 @@ public class FindRelationshipsTest extends CobolTest {
               000000*    EXEC SQL statement to declare a table
                          EXEC SQL DECLARE PROD_TBL_02 TABLE
                          ( NUM_1                  CHAR(3) NOT NULL,
-                           NUM_2                  CHAR(5) NOT NULL,
-                           CREATED_DATE           DATE NOT NULL
+                           NUM_2                  CHAR(5) NOT NULL
                          ) END-EXEC.
                          
                          01 DCL_PROD_TBL_02_NUM_1_CPY PIC X(3).
@@ -265,7 +271,7 @@ public class FindRelationshipsTest extends CobolTest {
               assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
               assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "PROD_TBL_02");
               assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
-              assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "DELETE");
+              assertThat(rows.stream().map(Row::getActionMetadata)).contains("CREATE", "DELETE");
           }),
           cobol(
             """
@@ -293,8 +299,7 @@ public class FindRelationshipsTest extends CobolTest {
               000000*    EXEC SQL statement to declare a table
                          EXEC SQL DECLARE PROD_TBL_02 TABLE
                          ( NUM_1                  CHAR(3) NOT NULL,
-                           NUM_2                  CHAR(5) NOT NULL,
-                           CREATED_DATE           DATE NOT NULL
+                           NUM_2                  CHAR(5) NOT NULL
                          ) END-EXEC.
                          
                          01 DCL_PROD_TBL_02_NUM_1_CPY PIC X(3).

--- a/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
+++ b/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
@@ -75,10 +75,10 @@ public class FindRelationshipsTest extends CobolTest {
     void execSqlCreate() {
         rewriteRun(
           spec -> spec.dataTable(Row.class, rows -> {
-              assertThat(rows.stream().map(Row::getDependent)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "EXEC_SQL_CREATE");
+              assertThat(rows.stream().map(Row::getDependent)).contains("DECLARE_TABLE_2", "EXEC_SQL_CREATE");
               assertThat(rows.stream().map(Row::getDependentType)).contains(COPYBOOK, COBOL);
               assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
-              assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "PROD_TBL_01", "PROD_TBL_02", "PROD_TBL_03");
+              assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "PROD_TBL_01", "PROD_TBL_02");
               assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
               assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "READ");
           }),
@@ -97,11 +97,6 @@ public class FindRelationshipsTest extends CobolTest {
                          ( NUM_1                  CHAR(3) NOT NULL,
                            NUM_2                  CHAR(5) NOT NULL
                          ) END-EXEC.
-
-                    * Include SQL table from another COBOL source.
-                    * These SQL tables are created through copybooks.
-                     EXEC SQL INCLUDE DECLARE_TABLE_2 END-EXEC.
-                     EXEC SQL INCLUDE DECLARE_TABLE_3 END-EXEC.
               
                     * Create cursors for tables
                     * Cursor for table 1
@@ -112,24 +107,10 @@ public class FindRelationshipsTest extends CobolTest {
                          FROM PROD_TBL_01
                          FOR FETCH ONLY
                      END-EXEC.
-              
-                    * Cursor for table 2
-                     EXEC SQL
-                         DECLARE CURSOR_2 CURSOR FOR
-                         SELECT NUM_1,
-                                NUM_2
-                         FROM PROD_TBL_02
-                         FOR FETCH ONLY
-                     END-EXEC.
-              
-                    * Cursor for table 3
-                     EXEC SQL
-                         DECLARE CURSOR_3 CURSOR FOR
-                         SELECT NUM_1,
-                                NUM_2
-                         FROM PROD_TBL_03
-                         FOR FETCH ONLY
-                     END-EXEC.
+
+                    * Include SQL table from another COBOL source.
+                    * These SQL tables are created through copybooks.
+                     EXEC SQL INCLUDE DECLARE_TABLE_2 END-EXEC.
               """,
             spec -> spec.after(s -> s).path("EXEC_SQL_CREATE.CBL")
           ),
@@ -140,26 +121,16 @@ public class FindRelationshipsTest extends CobolTest {
                          ( NUM_1                  CHAR(3) NOT NULL,
                            NUM_2                  CHAR(5) NOT NULL
                          ) END-EXEC.
-              """,
-            spec -> spec.after(s -> s).path("DECLARE_TABLE_2.CPY")
-          ),
-          preprocessor(
-            """
-              000000*    EXEC SQL statement to declare a table
-                         EXEC SQL DECLARE PROD_TBL_03 TABLE
-                         ( NUM_1                  CHAR(3) NOT NULL,
-                           NUM_2                  CHAR(5) NOT NULL
-                         ) END-EXEC.
-                    * Create cursor for table 3
+                    * Create cursor for table 2
                          EXEC SQL
                              DECLARE CURSOR_IN_COPY CURSOR FOR
                              SELECT NUM_1,
                                     NUM_2
-                             FROM PROD_TBL_03
+                             FROM PROD_TBL_02
                              FOR FETCH ONLY
                          END-EXEC.
               """,
-            spec -> spec.after(s -> s).path("DECLARE_TABLE_3.CPY")
+            spec -> spec.after(s -> s).path("DECLARE_TABLE_2.CPY")
           )
         );
     }
@@ -184,7 +155,7 @@ public class FindRelationshipsTest extends CobolTest {
                      WORKING-STORAGE SECTION.
                      01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
                      01 DCL_PROD_TBL_02_NUM_1 PIC X(3).
-              
+
                     * Include SQL table from another COBOL source.
                     * These SQL tables are created through copybooks.
                      EXEC SQL INCLUDE DECLARE_TABLE_2 END-EXEC.
@@ -229,6 +200,58 @@ public class FindRelationshipsTest extends CobolTest {
                      END-EXEC.
               """,
             spec -> spec.after(s -> s).path("DECLARE_TABLE_3.CPY")
+          )
+        );
+    }
+
+    @Test
+    void execSqlUpdate() {
+        rewriteRun(
+          spec -> spec.dataTable(Row.class, rows -> {
+              assertThat(rows.stream().map(Row::getDependent)).contains("DECLARE_TABLE_2", "EXEC_SQL_UPDATE");
+              assertThat(rows.stream().map(Row::getDependentType)).contains(COPYBOOK, COBOL);
+              assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
+              assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "PROD_TBL_02");
+              assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
+              assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "UPDATE");
+          }),
+          cobol(
+            """
+              000000 IDENTIFICATION DIVISION.
+                     PROGRAM-ID.
+                         EXEC_SQL_READ.
+                     DATA DIVISION.
+                     WORKING-STORAGE SECTION.
+                     01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
+                     01 DCL_PROD_TBL_02_NUM_1 PIC X(3).
+              
+                    * Include SQL table from another COBOL source.
+                    * These SQL tables are created through copybooks.
+                     EXEC SQL INCLUDE DECLARE_TABLE_2 END-EXEC.
+
+                     EXEC SQL
+                         UPDATE PROD_TBL_02
+                         SET NUM_1 = :DCL_PROD_TBL_02_NUM_1
+                     END-EXEC.
+              """,
+            spec -> spec.after(s -> s).path("EXEC_SQL_UPDATE.CBL")
+          ),
+          preprocessor(
+            """
+              000000*    EXEC SQL statement to declare a table
+                         EXEC SQL DECLARE PROD_TBL_02 TABLE
+                         ( NUM_1                  CHAR(3) NOT NULL,
+                           NUM_2                  CHAR(5) NOT NULL,
+                           CREATED_DATE           DATE NOT NULL
+                         ) END-EXEC.
+                         
+                         01 DCL_PROD_TBL_02_NUM_1_CPY PIC X(3).
+                         EXEC SQL
+                            UPDATE PROD_TBL_02
+                            SET NUM_1 = :DCL_PROD_TBL_02_NUM_1_CPY
+                         END-EXEC.
+              """,
+            spec -> spec.after(s -> s).path("DECLARE_TABLE_2.CPY")
           )
         );
     }

--- a/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
+++ b/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
@@ -75,17 +75,18 @@ public class FindRelationshipsTest extends CobolTest {
     void execSqlCreate() {
         rewriteRun(
           spec -> spec.dataTable(Row.class, rows -> {
-              assertThat(rows.stream().map(Row::getDependent)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "EXEC_SQL");
-              assertThat(rows.stream().map(Row::getDependency)).contains("PROD_TBL_01", "PROD_TBL_02", "PROD_TBL_03");
+              assertThat(rows.stream().map(Row::getDependent)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "EXEC_SQL_CREATE");
               assertThat(rows.stream().map(Row::getDependentType)).contains(COPYBOOK, COBOL);
-              assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, SQL_CURSOR);
-              assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, CREATE);
+              assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
+              assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "PROD_TBL_01", "PROD_TBL_02", "PROD_TBL_03");
+              assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
+              assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "READ");
           }),
           cobol(
             """
               000000 IDENTIFICATION DIVISION.
                      PROGRAM-ID.
-                         EXEC_SQL.
+                         EXEC_SQL_CREATE.
                      DATA DIVISION.
                      WORKING-STORAGE SECTION.
                      01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
@@ -94,10 +95,9 @@ public class FindRelationshipsTest extends CobolTest {
                     *    EXEC SQL statement to declare a table
                          EXEC SQL DECLARE PROD_TBL_01 TABLE
                          ( NUM_1                  CHAR(3) NOT NULL,
-                           NUM_2                  CHAR(5) NOT NULL,
-                           CREATED_DATE           DATE NOT NULL
+                           NUM_2                  CHAR(5) NOT NULL
                          ) END-EXEC.
-              
+
                     * Include SQL table from another COBOL source.
                     * These SQL tables are created through copybooks.
                      EXEC SQL INCLUDE DECLARE_TABLE_2 END-EXEC.
@@ -131,7 +131,76 @@ public class FindRelationshipsTest extends CobolTest {
                          FOR FETCH ONLY
                      END-EXEC.
               """,
-            spec -> spec.after(s -> s).path("EXEC_SQL.CBL")
+            spec -> spec.after(s -> s).path("EXEC_SQL_CREATE.CBL")
+          ),
+          preprocessor(
+            """
+              000000*    EXEC SQL statement to declare a table
+                         EXEC SQL DECLARE PROD_TBL_02 TABLE
+                         ( NUM_1                  CHAR(3) NOT NULL,
+                           NUM_2                  CHAR(5) NOT NULL
+                         ) END-EXEC.
+              """,
+            spec -> spec.after(s -> s).path("DECLARE_TABLE_2.CPY")
+          ),
+          preprocessor(
+            """
+              000000*    EXEC SQL statement to declare a table
+                         EXEC SQL DECLARE PROD_TBL_03 TABLE
+                         ( NUM_1                  CHAR(3) NOT NULL,
+                           NUM_2                  CHAR(5) NOT NULL
+                         ) END-EXEC.
+                    * Create cursor for table 3
+                         EXEC SQL
+                             DECLARE CURSOR_IN_COPY CURSOR FOR
+                             SELECT NUM_1,
+                                    NUM_2
+                             FROM PROD_TBL_03
+                             FOR FETCH ONLY
+                         END-EXEC.
+              """,
+            spec -> spec.after(s -> s).path("DECLARE_TABLE_3.CPY")
+          )
+        );
+    }
+
+    @Test
+    void execSqlRead() {
+        rewriteRun(
+          spec -> spec.dataTable(Row.class, rows -> {
+              assertThat(rows.stream().map(Row::getDependent)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "EXEC_SQL_READ");
+              assertThat(rows.stream().map(Row::getDependentType)).contains(COPYBOOK, COBOL);
+              assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, ACCESS);
+              assertThat(rows.stream().map(Row::getDependency)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "PROD_TBL_02", "PROD_TBL_03");
+              assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, COPYBOOK);
+              assertThat(rows.stream().map(Row::getMetadata)).contains("CREATE", "READ");
+          }),
+          cobol(
+            """
+              000000 IDENTIFICATION DIVISION.
+                     PROGRAM-ID.
+                         EXEC_SQL_READ.
+                     DATA DIVISION.
+                     WORKING-STORAGE SECTION.
+                     01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
+                     01 DCL_PROD_TBL_02_NUM_1 PIC X(3).
+              
+                    * Include SQL table from another COBOL source.
+                    * These SQL tables are created through copybooks.
+                     EXEC SQL INCLUDE DECLARE_TABLE_2 END-EXEC.
+                     EXEC SQL INCLUDE DECLARE_TABLE_3 END-EXEC.
+
+                     EXEC SQL
+                         SELECT COUNT(*)
+                         INTO :DCL_PROD_TBL_02_NUM_1
+                         FROM PROD_TBL_02
+                         WHERE EXISTS (
+                             SELECT *
+                             FROM PROD_TBL_03
+                         )
+                     END-EXEC.
+              """,
+            spec -> spec.after(s -> s).path("EXEC_SQL_READ.CBL")
           ),
           preprocessor(
             """
@@ -152,23 +221,16 @@ public class FindRelationshipsTest extends CobolTest {
                            NUM_2                  CHAR(5) NOT NULL,
                            CREATED_DATE           DATE NOT NULL
                          ) END-EXEC.
-                    * Create cursor for table 3
-                         EXEC SQL
-                             DECLARE CURSOR_IN_COPY CURSOR FOR
-                             SELECT NUM_1,
-                                    NUM_2
-                             FROM PROD_TBL_03
-                             FOR FETCH ONLY
-                         END-EXEC.
+                     01 DCL_PROD_TBL_03_NUM_2 PIC X(3).
+                     EXEC SQL
+                         SELECT COUNT(*)
+                         INTO :DCL_PROD_TBL_03_NUM_2
+                         FROM PROD_TBL_03
+                     END-EXEC.
               """,
             spec -> spec.after(s -> s).path("DECLARE_TABLE_3.CPY")
           )
         );
-    }
-
-    @Test
-    void execSqlRead() {
-
     }
 
     @Test

--- a/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
+++ b/src/test/java/org/openrewrite/cobol/search/FindRelationshipsTest.java
@@ -72,14 +72,14 @@ public class FindRelationshipsTest extends CobolTest {
     }
 
     @Test
-    void execSql() {
+    void execSqlCreate() {
         rewriteRun(
           spec -> spec.dataTable(Row.class, rows -> {
               assertThat(rows.stream().map(Row::getDependent)).contains("DECLARE_TABLE_2", "DECLARE_TABLE_3", "EXEC_SQL");
-              assertThat(rows.stream().map(Row::getDependency)).contains("PROD_TBL_01", "PROD_TBL_02", "PROD_TBL_03", "CURSOR_IN_COPY", "CURSOR_1", "CURSOR_2", "CURSOR_3");
+              assertThat(rows.stream().map(Row::getDependency)).contains("PROD_TBL_01", "PROD_TBL_02", "PROD_TBL_03");
               assertThat(rows.stream().map(Row::getDependentType)).contains(COPYBOOK, COBOL);
               assertThat(rows.stream().map(Row::getDependencyType)).contains(SQL_TABLE, SQL_CURSOR);
-              assertThat(rows.stream().map(Row::getAction)).contains(DECLARE, INCLUDE);
+              assertThat(rows.stream().map(Row::getAction)).contains(INCLUDE, CREATE);
           }),
           cobol(
             """
@@ -164,6 +164,11 @@ public class FindRelationshipsTest extends CobolTest {
             spec -> spec.after(s -> s).path("DECLARE_TABLE_3.CPY")
           )
         );
+    }
+
+    @Test
+    void execSqlRead() {
+
     }
 
     @Test

--- a/src/test/resources/gov/nist/EXEC_SQL_CREATE.CBL
+++ b/src/test/resources/gov/nist/EXEC_SQL_CREATE.CBL
@@ -1,0 +1,27 @@
+000000 IDENTIFICATION DIVISION.
+       PROGRAM-ID.
+           EXEC_SQL_CREATE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
+
+      * Create SQL table in the COBOL source.
+      *    EXEC SQL statement to declare a table
+           EXEC SQL DECLARE EXEC_SQL_CREATE_TBL TABLE
+           ( NUM_1                  CHAR(3) NOT NULL,
+             NUM_2                  CHAR(3) NOT NULL
+           ) END-EXEC.
+
+      * Create cursors for tables
+      * Cursor for table 1
+       EXEC SQL
+           DECLARE EXEC_SQL_CREATE_CURSOR CURSOR FOR
+           SELECT NUM_1,
+                  NUM_2
+           FROM EXEC_SQL_CREATE_TBL
+           FOR FETCH ONLY
+       END-EXEC.
+
+      * Include SQL table from another COBOL source.
+      * These SQL tables are created through copybooks.
+       EXEC SQL INCLUDE SQL_TBL END-EXEC.

--- a/src/test/resources/gov/nist/EXEC_SQL_DELETE.CBL
+++ b/src/test/resources/gov/nist/EXEC_SQL_DELETE.CBL
@@ -1,0 +1,16 @@
+000000 IDENTIFICATION DIVISION.
+       PROGRAM-ID.
+           EXEC_SQL_DELETE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
+       01 DCL_EXEC_SQL_DELETE_VAR PIC X(3).
+
+      * Include SQL table from another COBOL source.
+      * These SQL tables are created through copybooks.
+       EXEC SQL INCLUDE SQL_TBL END-EXEC.
+
+       EXEC SQL
+           DELETE FROM SQL_TBL
+           WHERE NUM_1 = :DCL_EXEC_SQL_DELETE_VAR
+       END-EXEC.

--- a/src/test/resources/gov/nist/EXEC_SQL_READ.CBL
+++ b/src/test/resources/gov/nist/EXEC_SQL_READ.CBL
@@ -1,0 +1,28 @@
+000000 IDENTIFICATION DIVISION.
+       PROGRAM-ID.
+           EXEC_SQL_READ.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
+       01 DCL_EXEC_SQL_READ_VAR PIC X(3).
+
+      * Create SQL table in the COBOL source.
+      *    EXEC SQL statement to declare a table
+           EXEC SQL DECLARE EXEC_SQL_READ_TBL TABLE
+           ( NUM_1                  CHAR(3) NOT NULL,
+             NUM_2                  CHAR(3) NOT NULL
+           ) END-EXEC.
+
+      * Include SQL table from another COBOL source.
+      * These SQL tables are created through copybooks.
+       EXEC SQL INCLUDE SQL_TBL END-EXEC.
+
+       EXEC SQL
+           SELECT COUNT(*)
+           INTO :DCL_EXEC_SQL_READ_VAR
+           FROM SQL_TBL
+           WHERE EXISTS (
+               SELECT *
+               FROM EXEC_SQL_READ_TBL
+           )
+       END-EXEC.

--- a/src/test/resources/gov/nist/EXEC_SQL_UPDATE.CBL
+++ b/src/test/resources/gov/nist/EXEC_SQL_UPDATE.CBL
@@ -1,0 +1,25 @@
+000000 IDENTIFICATION DIVISION.
+       PROGRAM-ID.
+           EXEC_SQL_UPDATE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 FILLER PIC X(10) VALUE 'PGM WORKING-STORAGE: EXEC_SQL_PROD_2'.
+       01 DCL_EXEC_SQL_UPDATE_NUM_1 PIC X(3).
+       01 DCL_EXEC_SQL_UPDATE_NUM_2 PIC X(3).
+
+      * Include SQL table from another COBOL source.
+      * These SQL tables are created through copybooks.
+       EXEC SQL INCLUDE SQL_TBL END-EXEC.
+
+       EXEC SQL
+           UPDATE SQL_TBL
+           SET NUM_1 = :DCL_EXEC_SQL_UPDATE_NUM_1
+       END-EXEC.
+
+       EXEC SQL
+           INSERT INTO SQL_TBL
+                  (NUM_1,
+                   NUM_2)
+           VALUES (:DCL_EXEC_SQL_UPDATE_NUM_1
+                   :DCL_EXEC_SQL_UPDATE_NUM_2)
+       END-EXEC.

--- a/src/test/resources/gov/nist/copybooks/SQL_TBL.CPY
+++ b/src/test/resources/gov/nist/copybooks/SQL_TBL.CPY
@@ -1,0 +1,46 @@
+000000* Declare SQL table
+       EXEC SQL DECLARE SQL_TBL TABLE
+       ( NUM_1                  CHAR(3) NOT NULL,
+         NUM_2                  CHAR(3) NOT NULL
+       ) END-EXEC.
+
+      * Declare local variables in copied source.
+       01 DCL_SQL_TBL_NUM_1     PIC X(3).
+       01 DCL_SQL_TBL_NUM_2     PIC X(3).
+
+      * SQL SELECT
+       EXEC SQL
+           SELECT NUM_1
+           INTO :DCL_SQL_TBL_NUM_1
+           FROM SQL_TBL
+       END-EXEC.
+
+      * SQL UPDATE
+       EXEC SQL
+          UPDATE SQL_TBL
+          SET NUM_2 = :DCL_SQL_TBL_NUM_1
+       END-EXEC.
+
+      * SQL INSERT
+       EXEC SQL
+           INSERT INTO SQL_TBL
+                  (NUM_1,
+                   NUM_2)
+           VALUES (:DCL_SQL_TBL_NUM_1
+                   :DCL_SQL_TBL_NUM_2)
+       END-EXEC.
+
+      * SQL DELETE
+       EXEC SQL
+           DELETE FROM SQL_TBL
+           WHERE NUM_1 = :DCL_SQL_TBL_NUM_1
+       END-EXEC.
+
+      * Create cursor for table 2
+       EXEC SQL
+           DECLARE CURSOR_FROM_SQL_TBL CURSOR FOR
+           SELECT NUM_1,
+                  NUM_2
+           FROM SQL_TBL
+           FOR FETCH ONLY
+       END-EXEC.


### PR DESCRIPTION
Changes:

- Completed support for SQL CRUD operations.
    - Convered SQL: declare, select, insert, update, delete.
- Added `actionMetadata` row to `CobolRelationships` for additional details.

fixes #85 
fixes #87