### PR TITLE
Fix printing cobol sources with trailing copybooks that do not contain trailing whitespace.

### DIFF
--- a/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyList;

--- a/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorOutputSourcePrinter.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorOutputSourcePrinter.java
@@ -666,7 +666,9 @@ public class CobolPreprocessorOutputSourcePrinter<P> extends CobolPreprocessorSo
 
         String afterStop = getColumnAlignmentAfterStop(numberOfSpaces);
         p.append(afterStop);
-        p.append(StringUtils.repeat(" ", numberOfSpaces));
+        if (numberOfSpaces != cobolDialect.getColumns().getOtherArea()) {
+            p.append(StringUtils.repeat(" ", numberOfSpaces));
+        }
     }
 
     /**

--- a/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
+++ b/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
@@ -184,13 +184,6 @@ class CobolParserCopyTest extends CobolTest {
                      LINKAGE SECTION.                                                 *
                          01  GRP-01.                                                  *
                              COPY INCEPTION.                                          *
-              
-                    *******************************************************************
-                    /                                                                 *
-                             02  SPECIAL-FLAGS.                                       *
-                                 03  DN7 PICTURE X.                                   *
-                                 03  DN8 PICTURE X.                                   *
-                                 03  DN9 PICTURE X.                                   *
               """,
             """
               IDENTIFICATION DIVISION.
@@ -202,10 +195,6 @@ class CobolParserCopyTest extends CobolTest {
                           03  DN1  PICTURE X(6).
                           03  DN2  PICTURE X(6).
                           03  DN3  PICTURE X(6).
-                      02  SPECIAL-FLAGS.
-                          03  DN7 PICTURE X.
-                          03  DN8 PICTURE X.
-                          03  DN9 PICTURE X.
               """
           )
         );

--- a/src/test/resources/gov/nist/copybooks/INCEPTION.CPY
+++ b/src/test/resources/gov/nist/copybooks/INCEPTION.CPY
@@ -1,2 +1,1 @@
 000000         COPY INCEPTION_2.
-                   COPY INCEPTION_3.

--- a/src/test/resources/gov/nist/copybooks/INCEPTION_2.CPY
+++ b/src/test/resources/gov/nist/copybooks/INCEPTION_2.CPY
@@ -1,1 +1,1 @@
-000000         02  SUB-CALLED.
+000000             COPY INCEPTION_3.

--- a/src/test/resources/gov/nist/copybooks/INCEPTION_3.CPY
+++ b/src/test/resources/gov/nist/copybooks/INCEPTION_3.CPY
@@ -1,3 +1,4 @@
-000000             03  DN1  PICTURE X(6).
+000000         02  SUB-CALLED.
+                   03  DN1  PICTURE X(6).
                    03  DN2  PICTURE X(6).
                    03  DN3  PICTURE X(6).


### PR DESCRIPTION
fixes #91