### PR TITLE
Upgrading Antlr to 4.13.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:latest.release")
     implementation(platform("org.openrewrite:rewrite-bom:${latest}"))
     implementation("org.openrewrite:rewrite-core")
-    implementation("org.antlr:antlr4:4.11.1")
+    implementation("org.antlr:antlr4:4.13.2")
     implementation("io.micrometer:micrometer-core:1.9.+")
     implementation("io.github.classgraph:classgraph:latest.release")
     runtimeOnly("org.openrewrite.tools:java-object-diff:latest.release")


### PR DESCRIPTION
## What's changed?

Upgrading ANTLR to 4.13.2 (latest release as of now) following https://github.com/openrewrite/rewrite/pull/5007

## What's your motivation?

Nothing specific strictly other than staying up-to-date.
I noticed we are using a >2y old version when debugging something and I thought we could upgrade.
