### PR TITLE
Remove excessive estimatedEffortPerOccurrence override

### DIFF
--- a/src/main/java/org/openrewrite/cobol/cleanup/RemoveWithDebuggingMode.java
+++ b/src/main/java/org/openrewrite/cobol/cleanup/RemoveWithDebuggingMode.java
@@ -17,7 +17,6 @@ import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.cobol.tree.CommentArea;
 import org.openrewrite.cobol.tree.Space;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
@@ -41,7 +40,6 @@ public class RemoveWithDebuggingMode extends Recipe {
 
 	Set<String> tags = singleton("RSPEC-4057");
 
-	Duration estimatedEffortPerOccurrence = Duration.ofMinutes(1_000_000);
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {


### PR DESCRIPTION
## Summary

- Remove the `estimatedEffortPerOccurrence` override from `RemoveWithDebuggingMode` which was set to `Duration.ofMinutes(1_000_000)` (1 million minutes)
- This caused the "time saved" metric to report **33,333h 20m** for just 2 occurrences, which is wildly inaccurate for a simple cleanup recipe
- The recipe now falls back to the `Recipe` base class default of **5 minutes** per occurrence

The inflated value was observed when running the recipe via Moderne CLI:

```
Run mod-run . --recipe=org.openrewrite.cobol.cleanup.RemoveWithDebuggingMode

Moderne CLI 3.57.4

> Running recipe org.openrewrite.cobol.cleanup.RemoveWithDebuggingMode

  0% (49s)    > bmuschko/mainframe-recipe-demo@main (114 other updates not logged)
  0% (49s)        ! The latest LST is not up to date
  0% (49s)        Fix results at .moderne/run/20260212145954-NGFaL/fix.patch
  0% (49s)        + Recipe run complete
100% (49s)    Done

1s saved by using previously built LSTs
33333h 20m saved by using recipes
```