### PR TITLE
Making copybook lexing / parsing errors actually report more meaningful line number information and allowing parsing of other files to continue after encountering a parse failure on a file.

### DIFF
--- a/src/main/java/org/openrewrite/cobol/CobolParser.java
+++ b/src/main/java/org/openrewrite/cobol/CobolParser.java
@@ -61,12 +61,12 @@ public class CobolParser implements Parser {
                 .copybooks(copybooks)
                 .build();
 
-        return acceptedInputs(sourceFiles).map(s -> parseInput(s, relativeTo, ctx, cobolPreprocessorParser));
+        ParsingEventListener parserListener = ParsingExecutionContextView.view(ctx).getParsingListener();
+        return acceptedInputs(sourceFiles).map(s -> parseInput(s, relativeTo, ctx, cobolPreprocessorParser, parserListener));
     }
 
     private SourceFile parseInput(Input input, @Nullable Path relativeTo, ExecutionContext ctx,
-                                  CobolPreprocessorParser cobolPreprocessorParser) {
-        ParsingEventListener parserListener = ParsingExecutionContextView.view(ctx).getParsingListener();
+                                  CobolPreprocessorParser cobolPreprocessorParser, ParsingEventListener parserListener) {
         try {
             parserListener.startedParsing(input);
             EncodingDetectingInputStream is = input.getSource(ctx);
@@ -82,12 +82,14 @@ public class CobolParser implements Parser {
             CobolPreprocessorOutputSourcePrinter<ExecutionContext> printWithoutColumns = new CobolPreprocessorOutputSourcePrinter<>(cobolDialect, false);
             printWithoutColumns.visit(preprocessedCU, cobolParserOutput);
 
+            CobolLexer lexer = new CobolLexer(CharStreams.fromString(cobolParserOutput.getOut()));
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
+
             org.openrewrite.cobol.internal.grammar.CobolParser parser =
-                    new org.openrewrite.cobol.internal.grammar.CobolParser(
-                            new CommonTokenStream(new CobolLexer(CharStreams.fromString(cobolParserOutput.getOut())))) {{
+                    new org.openrewrite.cobol.internal.grammar.CobolParser(new CommonTokenStream(lexer)) {{
                         _interp = new TimeLimitingParserATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
                     }};
-
             parser.removeErrorListeners();
             parser.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
 

--- a/src/main/java/org/openrewrite/cobol/CobolParser.java
+++ b/src/main/java/org/openrewrite/cobol/CobolParser.java
@@ -82,12 +82,9 @@ public class CobolParser implements Parser {
             CobolPreprocessorOutputSourcePrinter<ExecutionContext> printWithoutColumns = new CobolPreprocessorOutputSourcePrinter<>(cobolDialect, false);
             printWithoutColumns.visit(preprocessedCU, cobolParserOutput);
 
-            CobolLexer lexer = new CobolLexer(CharStreams.fromString(cobolParserOutput.getOut()));
-            lexer.removeErrorListeners();
-            lexer.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
-
             org.openrewrite.cobol.internal.grammar.CobolParser parser =
-                    new org.openrewrite.cobol.internal.grammar.CobolParser(new CommonTokenStream(lexer)) {{
+                    new org.openrewrite.cobol.internal.grammar.CobolParser(
+                            new CommonTokenStream(new CobolLexer(CharStreams.fromString(cobolParserOutput.getOut())))) {{
                         _interp = new TimeLimitingParserATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
                     }};
             parser.removeErrorListeners();

--- a/src/main/java/org/openrewrite/cobol/CobolParser.java
+++ b/src/main/java/org/openrewrite/cobol/CobolParser.java
@@ -88,7 +88,7 @@ public class CobolParser implements Parser {
                         _interp = new TimeLimitingParserATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
                     }};
             parser.removeErrorListeners();
-            parser.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
+            parser.addErrorListener(new ForwardingErrorListener(input.getPath()));
 
             // Print the pre-processed code to parse COBOL.
             PrintOutputCapture<ExecutionContext> sourceOutput = new PrintOutputCapture<>(new InMemoryExecutionContext());
@@ -143,18 +143,16 @@ public class CobolParser implements Parser {
 
     private static class ForwardingErrorListener extends BaseErrorListener {
         private final Path sourcePath;
-        private final ExecutionContext ctx;
 
-        private ForwardingErrorListener(Path sourcePath, ExecutionContext ctx) {
+        private ForwardingErrorListener(Path sourcePath) {
             this.sourcePath = sourcePath;
-            this.ctx = ctx;
         }
 
         @Override
         public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
                                 int line, int charPositionInLine, String msg, RecognitionException e) {
-            ctx.getOnError().accept(new CobolParsingException(sourcePath,
-                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath, line, charPositionInLine, msg), e));
+            throw new CobolParsingException(sourcePath,
+                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath, line, charPositionInLine, msg), e);
         }
     }
 

--- a/src/main/java/org/openrewrite/cobol/CobolParsingException.java
+++ b/src/main/java/org/openrewrite/cobol/CobolParsingException.java
@@ -17,7 +17,7 @@ package org.openrewrite.cobol;
 
 import java.nio.file.Path;
 
-public class CobolParsingException extends Exception {
+public class CobolParsingException extends RuntimeException {
     private final Path sourcePath;
 
     public CobolParsingException(Path sourcePath, String message, Throwable t) {

--- a/src/main/java/org/openrewrite/cobol/CobolPreprocessorParser.java
+++ b/src/main/java/org/openrewrite/cobol/CobolPreprocessorParser.java
@@ -71,9 +71,13 @@ public class CobolPreprocessorParser implements Parser {
                         String sourceStr = is.readFully();
 
                         String prepareSource = new CobolLineReader().readLines(sourceStr, cobolDialect);
+
+                        CobolPreprocessorLexer lexer = new CobolPreprocessorLexer(CharStreams.fromString(prepareSource));
+                        lexer.removeErrorListeners();
+                        lexer.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
+
                         org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser parser =
-                                new org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser(
-                                        new CommonTokenStream(new CobolPreprocessorLexer(CharStreams.fromString(prepareSource))));
+                                new org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser(new CommonTokenStream(lexer));
                         parser.removeErrorListeners();
                         parser.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
 

--- a/src/main/java/org/openrewrite/cobol/CobolPreprocessorParser.java
+++ b/src/main/java/org/openrewrite/cobol/CobolPreprocessorParser.java
@@ -74,12 +74,12 @@ public class CobolPreprocessorParser implements Parser {
 
                         CobolPreprocessorLexer lexer = new CobolPreprocessorLexer(CharStreams.fromString(prepareSource));
                         lexer.removeErrorListeners();
-                        lexer.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
+                        lexer.addErrorListener(new ForwardingErrorListener(sourceFile.getPath()));
 
                         org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser parser =
                                 new org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser(new CommonTokenStream(lexer));
                         parser.removeErrorListeners();
-                        parser.addErrorListener(new ForwardingErrorListener(sourceFile.getPath(), ctx));
+                        parser.addErrorListener(new ForwardingErrorListener(sourceFile.getPath()));
 
                         CobolPreprocessorParserVisitor parserVisitor = new CobolPreprocessorParserVisitor(
                                 sourceFile.getRelativePath(relativeTo),
@@ -137,18 +137,16 @@ public class CobolPreprocessorParser implements Parser {
 
     private static class ForwardingErrorListener extends BaseErrorListener {
         private final Path sourcePath;
-        private final ExecutionContext ctx;
 
-        private ForwardingErrorListener(Path sourcePath, ExecutionContext ctx) {
+        private ForwardingErrorListener(Path sourcePath) {
             this.sourcePath = sourcePath;
-            this.ctx = ctx;
         }
 
         @Override
         public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
                                 int line, int charPositionInLine, String msg, RecognitionException e) {
-            ctx.getOnError().accept(new CobolParsingException(sourcePath,
-                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath, line, charPositionInLine, msg), e));
+            throw new CobolParsingException(sourcePath,
+                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath, line, charPositionInLine, msg), e);
         }
     }
 

--- a/src/main/java/org/openrewrite/cobol/CopybookParser.java
+++ b/src/main/java/org/openrewrite/cobol/CopybookParser.java
@@ -82,12 +82,12 @@ public class CopybookParser implements Parser {
 
             CobolPreprocessorLexer lexer = new CobolPreprocessorLexer(CharStreams.fromString(prepareSource));
             lexer.removeErrorListeners();
-            lexer.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
+            lexer.addErrorListener(new ForwardingErrorListener(input.getPath()));
 
             org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser parser =
                     new org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser(new CommonTokenStream(lexer));
             parser.removeErrorListeners();
-            parser.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
+            parser.addErrorListener(new ForwardingErrorListener(input.getPath()));
 
             CobolPreprocessorParserVisitor parserVisitor = new CobolPreprocessorParserVisitor(
                     input.getRelativePath(relativeTo),
@@ -145,18 +145,16 @@ public class CopybookParser implements Parser {
 
     private static class ForwardingErrorListener extends BaseErrorListener {
         private final Path sourcePath;
-        private final ExecutionContext ctx;
 
-        private ForwardingErrorListener(Path sourcePath, ExecutionContext ctx) {
+        private ForwardingErrorListener(Path sourcePath) {
             this.sourcePath = sourcePath;
-            this.ctx = ctx;
         }
 
         @Override
         public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
                                 int line, int charPositionInLine, String msg, RecognitionException e) {
-            ctx.getOnError().accept(new CopybookParsingException(sourcePath,
-                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath, line, charPositionInLine, msg), e));
+            throw new CopybookParsingException(sourcePath,
+                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath, line, charPositionInLine, msg), e);
         }
     }
 

--- a/src/main/java/org/openrewrite/cobol/CopybookParser.java
+++ b/src/main/java/org/openrewrite/cobol/CopybookParser.java
@@ -15,8 +15,7 @@
  */
 package org.openrewrite.cobol;
 
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.*;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
@@ -32,6 +31,7 @@ import org.openrewrite.internal.EncodingDetectingInputStream;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.tree.ParseError;
+import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
 import java.nio.file.Path;
@@ -56,11 +56,13 @@ public class CopybookParser implements Parser {
 
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
-        return acceptedInputs(sourceFiles).map(input -> parseInput(input, relativeTo, ctx));
+        ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
+        return acceptedInputs(sourceFiles).map(input -> parseInput(input, relativeTo, ctx, parsingListener));
     }
 
-    private SourceFile parseInput(Input input, @Nullable Path relativeTo, ExecutionContext ctx) {
+    private SourceFile parseInput(Input input, @Nullable Path relativeTo, ExecutionContext ctx, ParsingEventListener parsingListener) {
         try {
+            parsingListener.startedParsing(input);
             EncodingDetectingInputStream is = input.getSource(ctx);
             String sourceStr = is.readFully();
 
@@ -77,9 +79,15 @@ public class CopybookParser implements Parser {
             );
 
             String prepareSource = new CobolLineReader().readLines(sourceStr, cobolDialect);
+
+            CobolPreprocessorLexer lexer = new CobolPreprocessorLexer(CharStreams.fromString(prepareSource));
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
+
             org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser parser =
-                    new org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser(
-                            new CommonTokenStream(new CobolPreprocessorLexer(CharStreams.fromString(prepareSource))));
+                    new org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser(new CommonTokenStream(lexer));
+            parser.removeErrorListeners();
+            parser.addErrorListener(new ForwardingErrorListener(input.getPath(), ctx));
 
             CobolPreprocessorParserVisitor parserVisitor = new CobolPreprocessorParserVisitor(
                     input.getRelativePath(relativeTo),
@@ -106,7 +114,7 @@ public class CopybookParser implements Parser {
                     preprocessedCU.getEof()
             );
 
-            ParsingExecutionContextView.view(ctx).getParsingListener().parsed(input, preprocessedCU);
+            parsingListener.parsed(input, preprocessedCU);
             return copybook;
         } catch (Throwable t) {
             ctx.getOnError().accept(t);
@@ -133,6 +141,23 @@ public class CopybookParser implements Parser {
     @Override
     public Path sourcePathFromSourceText(Path prefix, String sourceCode) {
         return prefix.resolve("file.CPY");
+    }
+
+    private static class ForwardingErrorListener extends BaseErrorListener {
+        private final Path sourcePath;
+        private final ExecutionContext ctx;
+
+        private ForwardingErrorListener(Path sourcePath, ExecutionContext ctx) {
+            this.sourcePath = sourcePath;
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                int line, int charPositionInLine, String msg, RecognitionException e) {
+            ctx.getOnError().accept(new CopybookParsingException(sourcePath,
+                    String.format("Syntax error in %s at line %d:%d %s.", sourcePath, line, charPositionInLine, msg), e));
+        }
     }
 
     public static CopybookParser.Builder builder() {

--- a/src/main/java/org/openrewrite/cobol/CopybookParsingException.java
+++ b/src/main/java/org/openrewrite/cobol/CopybookParsingException.java
@@ -1,0 +1,16 @@
+package org.openrewrite.cobol;
+
+import java.nio.file.Path;
+
+public class CopybookParsingException extends Exception {
+    private final Path sourcePath;
+
+    public CopybookParsingException(Path sourcePath, String message, Throwable t) {
+        super(message, t);
+        this.sourcePath = sourcePath;
+    }
+
+    public Path getSourcePath() {
+        return sourcePath;
+    }
+}

--- a/src/main/java/org/openrewrite/cobol/CopybookParsingException.java
+++ b/src/main/java/org/openrewrite/cobol/CopybookParsingException.java
@@ -2,7 +2,7 @@ package org.openrewrite.cobol;
 
 import java.nio.file.Path;
 
-public class CopybookParsingException extends Exception {
+public class CopybookParsingException extends RuntimeException {
     private final Path sourcePath;
 
     public CopybookParsingException(Path sourcePath, String message, Throwable t) {

--- a/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorParserVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorParserVisitor.java
@@ -963,6 +963,9 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
 
 			String current = source.substring(cursor);
 			int newLinePos = current.indexOf("\n");
+			if (newLinePos > 0 && current.charAt(newLinePos - 1) == '\r') {
+				newLinePos--;
+			}
 			int endPos = (nextCommentArea != null && nextCommentArea < (newLinePos + cursor)) ? nextCommentArea : (newLinePos + cursor);
 
 			current = source.substring(cursor, endPos).trim();
@@ -1006,6 +1009,9 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
                 }
 
                 int newLinePos = cursor + (source.substring(cursor).contains("\n") ? source.substring(cursor).indexOf("\n") : source.substring(cursor).length());
+                if (newLinePos > cursor && source.charAt(newLinePos - 1) == '\r') {
+                    newLinePos--;
+                }
                 int endOfContentArea = cursor - cobolDialect.getColumns().getIndicatorArea() - 1 + cobolDialect.getColumns().getOtherArea();
                 String contentArea = source.substring(cursor, Math.min(newLinePos, endOfContentArea));
                 if (!(isCommentIndicator(indicatorArea) || contentArea.trim().isEmpty())) {

--- a/src/test/java/org/openrewrite/cobol/tree/preprocessor/CobolPreprocessorCopybookTest.java
+++ b/src/test/java/org/openrewrite/cobol/tree/preprocessor/CobolPreprocessorCopybookTest.java
@@ -16,9 +16,25 @@
 package org.openrewrite.cobol.tree.preprocessor;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.cobol.CobolParser;
 import org.openrewrite.cobol.CobolTest;
+import org.openrewrite.tree.ParseError;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.cobol.Assertions.copybook;
 
 class CobolPreprocessorCopybookTest extends CobolTest {
@@ -389,5 +405,41 @@ class CobolPreprocessorCopybookTest extends CobolTest {
         rewriteRun(
           copybook(getNistResource("K1WKA_TRAILING_SUB.CPY"))
         );
+    }
+
+    @Test
+    void syntaxErrorProducesParseErrorWithoutStoppingStream() {
+        CobolParser parser = CobolParser.builder()
+                .copybooks(Collections.emptyList())
+                .timeout(Duration.ofSeconds(10))
+                .build();
+
+        String validCobol = """
+                000001 IDENTIFICATION DIVISION.
+                000002 PROGRAM-ID. HELLO.
+                000003 PROCEDURE DIVISION.
+                000004     STOP RUN.
+                """;
+
+        String invalidCobol = """
+                000001 BLAH BLAH THIS IS NOT A VALID COBOL PROGRAM.
+                000002 IT SHOULD CAUSE A PARSE ERROR.
+                """;
+
+        List<Parser.Input> inputs = Arrays.asList(
+                new Parser.Input(Paths.get("valid1.cbl"), () -> new ByteArrayInputStream(validCobol.getBytes(StandardCharsets.UTF_8))),
+                new Parser.Input(Paths.get("invalid.cbl"), () -> new ByteArrayInputStream(invalidCobol.getBytes(StandardCharsets.UTF_8))),
+                new Parser.Input(Paths.get("valid2.cbl"), () -> new ByteArrayInputStream(validCobol.getBytes(StandardCharsets.UTF_8)))
+        );
+
+        List<Throwable> errors = new ArrayList<>();
+        InMemoryExecutionContext ctx = new InMemoryExecutionContext(errors::add);
+
+        List<SourceFile> results = parser.parseInputs(inputs, null, ctx)
+                .collect(Collectors.toList());
+
+        assertThat(results).hasSize(3);
+        assertThat(results.get(1)).isInstanceOf(ParseError.class);
+        assertThat(errors).isNotEmpty();
     }
 }


### PR DESCRIPTION
I've debugged it to see the error being forwarded, but haven't figured out if there's actually a way to write an automated test to check this, as the conditions that will trigger this result in the test not being able to parse the inputs and so not being able to parse afterRecipe checks.

Ultimately what I'm aiming for 
```cobol
000000 IDENTIFICATION DIVISION.                                         *
       PROGRAM-ID. HELLO.                                               *
       PROCEDURE DIVISION.                                              *
           DISPLAY "Hello, World!".                                     *
           STOP RUN.                                                    *
       COPY JOOEXADR                                                    *
```
(note the lack of `.` after the `COPY JOOEXADR`)
to be able to indicate the problem lines effectively, and be able to recover/continue afterwards.

The exception in this instance should be something like:
```
org.openrewrite.cobol.CopybookParsingException: Syntax error in file.CPY at line 6:65 mismatched input '<EOF>' expecting {'IN', 'OF', 'ON', 'REPLACING', 'SUPPRESS', '.'}.
	at org.openrewrite.cobol.CopybookParser$ForwardingErrorListener.syntaxError(CopybookParser.java:159)
	... 28 more
Caused by: org.antlr.v4.runtime.InputMismatchException
	at org.antlr.v4.runtime.DefaultErrorStrategy.sync(DefaultErrorStrategy.java:270)
	at org.openrewrite.cobol.internal.grammar.CobolPreprocessorParser.copyStatement(CobolPreprocessorParser.java:3939)
	... 23 more
```

Logic was based on what I was seeing in the `XmlParser` in `openrewrite/rewrite`.

---

### Additional changes

**Add ForwardingErrorListener to CobolPreprocessorParser lexer and fix CI** — The `CobolPreprocessorLexer` in `CobolPreprocessorParser` was not configured with `ForwardingErrorListener`, unlike the other parsers. Extracted the lexer creation and added `removeErrorListeners()` / `addErrorListener(new ForwardingErrorListener(...))`. Also reverted the `ForwardingErrorListener` on the `CobolLexer` in `CobolParser` which was causing `sm201ATrailingSub()` to fail — the NIST test file has a benign token recognition error that ANTLR's default recovery handles fine.

**Exclude \r from content area boundaries for CRLF compatibility** — Fixed two places in `CobolPreprocessorParserVisitor` where `newLinePos` calculations would include `\r` on Windows CRLF files, corrupting content area substrings in `processTokenText` and `parseCommentsAndEmptyLines`.

**Fix double-error bug in ForwardingErrorListener** — `ForwardingErrorListener.syntaxError()` was calling `ctx.getOnError().accept()` directly. If the error handler threw, the outer `catch` block would call `ctx.getOnError().accept()` a second time, terminating the entire parsing stream — one bad file would prevent all subsequent files from being processed. Changed both `CobolParsingException` and `CopybookParsingException` to extend `RuntimeException` and have `ForwardingErrorListener` throw directly. The outer `catch` block now handles the error exactly once and returns `ParseError`, allowing the stream to continue. Added a test confirming a syntax error in one file produces a `ParseError` without stopping subsequent files.