### PR TITLE
Add data tables to search recipes for CLI output

### DIFF
--- a/src/main/java/org/openrewrite/cobol/search/FindIndicators.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindIndicators.java
@@ -45,30 +45,21 @@ public class FindIndicators extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new AddSearchResult(indicator, indicatorSearchResult);
-    }
-
-    private static class AddSearchResult extends CobolIsoVisitor<ExecutionContext> {
-        private final String indicator;
-        private final IndicatorSearchResult indicatorSearchResult;
-
-        public AddSearchResult(String indicator, IndicatorSearchResult indicatorSearchResult) {
-            this.indicator = indicator;
-            this.indicatorSearchResult = indicatorSearchResult;
-        }
-
-        @Override
-        public Cobol.Word visitWord(Cobol.Word word, ExecutionContext ctx) {
-            if (word.getIndicatorArea() != null && word.getIndicatorArea().getIndicator().equals(indicator)) {
-                indicatorSearchResult.insertRow(ctx, new IndicatorSearchResult.Row(
-                        getCursor().firstEnclosingOrThrow(Cobol.CompilationUnit.class).getSourcePath().toString(),
-                        word.getIndicatorArea().getIndicator(),
-                        word.getWord()));
-                word = word.withIndicatorArea(
-                        word.getIndicatorArea().withMarkers(
-                                word.getIndicatorArea().getMarkers().addIfAbsent(new SearchResult(randomId(), null))));
+        return new CobolIsoVisitor<ExecutionContext>() {
+            @Override
+            public Cobol.Word visitWord(Cobol.Word word, ExecutionContext ctx) {
+                if (word.getIndicatorArea() != null && word.getIndicatorArea().getIndicator().equals(indicator)) {
+                    indicatorSearchResult.insertRow(ctx, new IndicatorSearchResult.Row(
+                            getCursor().firstEnclosingOrThrow(Cobol.CompilationUnit.class).getSourcePath().toString(),
+                            word.getIndicatorArea().getIndicator(),
+                            word.getWord()));
+                    return word.withIndicatorArea(
+                            word.getIndicatorArea().withMarkers(
+                                    word.getIndicatorArea().getMarkers().addIfAbsent(new SearchResult(randomId(), null))));
+                }
+                return word;
             }
-            return word;
-        }
+        };
     }
+
 }

--- a/src/main/java/org/openrewrite/cobol/search/FindIndicators.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindIndicators.java
@@ -22,6 +22,7 @@ import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.cobol.CobolIsoVisitor;
+import org.openrewrite.cobol.table.IndicatorSearchResult;
 import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.marker.SearchResult;
 
@@ -36,26 +37,33 @@ public class FindIndicators extends Recipe {
             example = "D")
     String indicator;
 
+    transient IndicatorSearchResult indicatorSearchResult = new IndicatorSearchResult(this);
+
     String displayName = "Find indicators";
 
     String description = "Find matching indicators. Currently, this recipe will not mark indicators on copybook code.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new AddSearchResult(indicator);
+        return new AddSearchResult(indicator, indicatorSearchResult);
     }
 
     private static class AddSearchResult extends CobolIsoVisitor<ExecutionContext> {
         private final String indicator;
+        private final IndicatorSearchResult indicatorSearchResult;
 
-        public AddSearchResult(String indicator) {
+        public AddSearchResult(String indicator, IndicatorSearchResult indicatorSearchResult) {
             this.indicator = indicator;
+            this.indicatorSearchResult = indicatorSearchResult;
         }
-
 
         @Override
         public Cobol.Word visitWord(Cobol.Word word, ExecutionContext ctx) {
             if (word.getIndicatorArea() != null && word.getIndicatorArea().getIndicator().equals(indicator)) {
+                indicatorSearchResult.insertRow(ctx, new IndicatorSearchResult.Row(
+                        getCursor().firstEnclosingOrThrow(Cobol.CompilationUnit.class).getSourcePath().toString(),
+                        word.getIndicatorArea().getIndicator(),
+                        word.getWord()));
                 word = word.withIndicatorArea(
                         word.getIndicatorArea().withMarkers(
                                 word.getIndicatorArea().getMarkers().addIfAbsent(new SearchResult(randomId(), null))));

--- a/src/main/java/org/openrewrite/cobol/search/FindReference.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindReference.java
@@ -71,13 +71,13 @@ public class FindReference extends Recipe {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
 				if (tree instanceof Cobol) {
-					return cobolReference.visit(tree, ctx);
+					return cobolReference.visit(tree, ctx, getCursor().getParentOrThrow());
 				}
 				if (tree instanceof CobolPreprocessor.Copybook) {
-					return copybookReference.visit(tree, ctx);
+					return copybookReference.visit(tree, ctx, getCursor().getParentOrThrow());
 				}
 				if (tree instanceof Jcl.CompilationUnit) {
-					return jclReference.visit(tree, ctx);
+					return jclReference.visit(tree, ctx, getCursor().getParentOrThrow());
 				}
 				return super.visit(tree, ctx);
 			}

--- a/src/main/java/org/openrewrite/cobol/search/FindReference.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindReference.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.cobol.CobolPreprocessorVisitor;
 import org.openrewrite.cobol.NameVisitor;
+import org.openrewrite.cobol.table.ReferenceSearchResult;
 import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.cobol.tree.CobolPreprocessor;
 import org.openrewrite.jcl.JclIsoVisitor;
@@ -43,6 +44,8 @@ public class FindReference extends Recipe {
             description = "Search for a word based on an exact match of the search term.",
             example = "true")
     Boolean exactMatch;
+
+    transient ReferenceSearchResult referenceSearchResult = new ReferenceSearchResult(this);
 
     String displayName = "Find matching identifiers in COBOL, copybooks, and JCL";
 
@@ -83,6 +86,10 @@ public class FindReference extends Recipe {
                 @Override
                 public Cobol.Word visitWord(Cobol.Word word, ExecutionContext ctx) {
                     if (matches(word.getWord())) {
+                        referenceSearchResult.insertRow(ctx, new ReferenceSearchResult.Row(
+                                getCursor().firstEnclosingOrThrow(Cobol.CompilationUnit.class).getSourcePath().toString(),
+                                ReferenceSearchResult.SourceType.COBOL,
+                                word.getWord()));
                         return SearchResult.found(word);
                     }
                     return super.visitWord(word, ctx);
@@ -90,9 +97,21 @@ public class FindReference extends Recipe {
             }
 
             class CopybookReference extends CobolPreprocessorVisitor<ExecutionContext> {
+                private String sourcePath = "";
+
+                @Override
+                public CobolPreprocessor visitCopybook(CobolPreprocessor.Copybook copybook, ExecutionContext ctx) {
+                    sourcePath = copybook.getSourcePath().toString();
+                    return super.visitCopybook(copybook, ctx);
+                }
+
                 @Override
                 public CobolPreprocessor visitWord(CobolPreprocessor.Word word, ExecutionContext ctx) {
                     if (matches(word.getCobolWord().getWord())) {
+                        referenceSearchResult.insertRow(ctx, new ReferenceSearchResult.Row(
+                                sourcePath,
+                                ReferenceSearchResult.SourceType.COPYBOOK,
+                                word.getCobolWord().getWord()));
                         return SearchResult.found(word);
                     }
                     return super.visitWord(word, ctx);

--- a/src/main/java/org/openrewrite/cobol/search/FindWord.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindWord.java
@@ -25,6 +25,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.cobol.CobolPreprocessorIsoVisitor;
 import org.openrewrite.cobol.NameVisitor;
 import org.openrewrite.cobol.marker.CopiedWord;
+import org.openrewrite.cobol.table.WordSearchResult;
 import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.cobol.tree.CobolPreprocessor;
 import org.openrewrite.cobol.tree.Replacement;
@@ -49,24 +50,28 @@ public class FindWord extends Recipe {
             example = "true")
     Boolean exactMatch;
 
+    transient WordSearchResult wordSearchResult = new WordSearchResult(this);
+
     String displayName = "Find matching words in the source code";
 
     String description = "Search for COBOL words based on a search term.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new SearchForWord(searchTerm, exactMatch);
+        return new SearchForWord(searchTerm, exactMatch, wordSearchResult);
     }
 
     private static class SearchForWord extends NameVisitor<ExecutionContext> {
         private final PreprocessorSearch preprocessorSearch;
         private final String searchTerm;
+        private final WordSearchResult wordSearchResult;
 
         @Nullable
         private final Pattern pattern;
 
-        public SearchForWord(String searchTerm, @Nullable Boolean exactMatch) {
+        public SearchForWord(String searchTerm, @Nullable Boolean exactMatch, WordSearchResult wordSearchResult) {
             this.searchTerm = searchTerm;
+            this.wordSearchResult = wordSearchResult;
             pattern = Boolean.TRUE.equals(exactMatch) ? null : Pattern.compile(searchTerm.toLowerCase());
             preprocessorSearch = new PreprocessorSearch();
         }
@@ -95,6 +100,9 @@ public class FindWord extends Recipe {
             }
 
             if (matches(w.getWord())) {
+                wordSearchResult.insertRow(ctx, new WordSearchResult.Row(
+                        getCursor().firstEnclosingOrThrow(Cobol.CompilationUnit.class).getSourcePath().toString(),
+                        w.getWord()));
                 return SearchResult.found(word);
             }
             return w;
@@ -104,6 +112,9 @@ public class FindWord extends Recipe {
             @Override
             public CobolPreprocessor.Word visitWord(CobolPreprocessor.Word word, ExecutionContext ctx) {
                 if (matches(word.getCobolWord().getWord())) {
+                    wordSearchResult.insertRow(ctx, new WordSearchResult.Row(
+                            SearchForWord.this.getCursor().firstEnclosingOrThrow(Cobol.CompilationUnit.class).getSourcePath().toString(),
+                            word.getCobolWord().getWord()));
                     return SearchResult.found(word);
                 }
                 return word;

--- a/src/main/java/org/openrewrite/cobol/search/FindWord.java
+++ b/src/main/java/org/openrewrite/cobol/search/FindWord.java
@@ -84,7 +84,7 @@ public class FindWord extends Recipe {
                 if (it instanceof CobolPreprocessor.CopyStatement && !hasCopyStatement.get()) {
                     hasCopyStatement.set(true);
                 }
-                return preprocessorSearch.visit(it, ctx);
+                return preprocessorSearch.visit(it, ctx, getCursor().getParentOrThrow());
             }));
 
             if (hasCopyStatement.get() || w.getMarkers().findFirst(CopiedWord.class).isPresent()) {
@@ -113,7 +113,7 @@ public class FindWord extends Recipe {
             public CobolPreprocessor.Word visitWord(CobolPreprocessor.Word word, ExecutionContext ctx) {
                 if (matches(word.getCobolWord().getWord())) {
                     wordSearchResult.insertRow(ctx, new WordSearchResult.Row(
-                            SearchForWord.this.getCursor().firstEnclosingOrThrow(Cobol.CompilationUnit.class).getSourcePath().toString(),
+                            getCursor().firstEnclosingOrThrow(Cobol.CompilationUnit.class).getSourcePath().toString(),
                             word.getCobolWord().getWord()));
                     return SearchResult.found(word);
                 }

--- a/src/main/java/org/openrewrite/cobol/table/IndicatorSearchResult.java
+++ b/src/main/java/org/openrewrite/cobol/table/IndicatorSearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/cobol/table/IndicatorSearchResult.java
+++ b/src/main/java/org/openrewrite/cobol/table/IndicatorSearchResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.cobol.table;
+
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+public class IndicatorSearchResult extends DataTable<IndicatorSearchResult.Row> {
+
+    public IndicatorSearchResult(Recipe recipe) {
+        super(recipe, "COBOL indicator search results",
+                "Indicator area matches found in COBOL source code.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Source path",
+                description = "The source path of the file that contains the matching indicator.")
+        String sourcePath;
+
+        @Column(displayName = "Indicator",
+                description = "The indicator character found in the indicator area.")
+        String indicator;
+
+        @Column(displayName = "Word",
+                description = "The word text on the line where the indicator was found.")
+        String word;
+    }
+}

--- a/src/main/java/org/openrewrite/cobol/table/ReferenceSearchResult.java
+++ b/src/main/java/org/openrewrite/cobol/table/ReferenceSearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/cobol/table/ReferenceSearchResult.java
+++ b/src/main/java/org/openrewrite/cobol/table/ReferenceSearchResult.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.cobol.table;
+
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+public class ReferenceSearchResult extends DataTable<ReferenceSearchResult.Row> {
+
+    public ReferenceSearchResult(Recipe recipe) {
+        super(recipe, "COBOL reference search results",
+                "Identifier references found in COBOL, copybook, and JCL sources.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Source path",
+                description = "The source path of the file that contains the matching reference.")
+        String sourcePath;
+
+        @Column(displayName = "Source type",
+                description = "The type of source where the reference was found.")
+        SourceType sourceType;
+
+        @Column(displayName = "Reference",
+                description = "The identifier text that matched the search criteria.")
+        String reference;
+    }
+
+    public enum SourceType {
+        COBOL,
+        COPYBOOK,
+        JCL
+    }
+}

--- a/src/main/java/org/openrewrite/cobol/table/WordSearchResult.java
+++ b/src/main/java/org/openrewrite/cobol/table/WordSearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/cobol/table/WordSearchResult.java
+++ b/src/main/java/org/openrewrite/cobol/table/WordSearchResult.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.cobol.table;
+
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+public class WordSearchResult extends DataTable<WordSearchResult.Row> {
+
+    public WordSearchResult(Recipe recipe) {
+        super(recipe, "COBOL word search results",
+                "Words in COBOL source code that match the search criteria.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Source path",
+                description = "The source path of the file that contains the matching word.")
+        String sourcePath;
+
+        @Column(displayName = "Matched word",
+                description = "The word text that matched the search criteria.")
+        String matchedWord;
+    }
+}

--- a/src/test/java/org/openrewrite/cobol/search/FindIndicatorsTest.java
+++ b/src/test/java/org/openrewrite/cobol/search/FindIndicatorsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.cobol.CobolTest;
+import org.openrewrite.cobol.table.IndicatorSearchResult;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.SearchResult;
@@ -28,6 +29,7 @@ import org.openrewrite.test.RecipeSpec;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.cobol.Assertions.cobol;
 
 class FindIndicatorsTest extends CobolTest {
@@ -50,7 +52,11 @@ class FindIndicatorsTest extends CobolTest {
     @Test
     void sm206a() {
         rewriteRun(
-          spec -> spec.recipe(new CompositeRecipe(List.of(new FindIndicators("S"), new FindIndicators("Y")))),
+          spec -> spec.recipe(new CompositeRecipe(List.of(new FindIndicators("S"), new FindIndicators("Y"))))
+              .dataTable(IndicatorSearchResult.Row.class, rows ->
+                  assertThat(rows).isNotEmpty()
+                      .extracting(IndicatorSearchResult.Row::getIndicator)
+                      .containsOnly("S", "Y")),
           cobol(getNistResource("SM206A.CBL"),
             """
               000100 IDENTIFICATION DIVISION.                                         SM2064.2

--- a/src/test/java/org/openrewrite/cobol/search/FindWordTest.java
+++ b/src/test/java/org/openrewrite/cobol/search/FindWordTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.cobol.CobolTest;
+import org.openrewrite.cobol.table.WordSearchResult;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RecipeSpec;
@@ -48,6 +49,10 @@ class FindWordTest extends CobolTest {
 
 	@DocumentExample @Test void cm102mExactMatch() {
         rewriteRun(
+          spec -> spec.dataTable(WordSearchResult.Row.class, rows ->
+              assertThat(rows).singleElement()
+                  .extracting(WordSearchResult.Row::getMatchedWord)
+                  .isEqualTo("CM102M")),
           cobol(
             """
               000100 IDENTIFICATION DIVISION.                                         CM1024.2
@@ -101,7 +106,11 @@ class FindWordTest extends CobolTest {
     @Test
     void sm101A() {
         rewriteRun(
-          spec -> spec.recipe(new FindWord("PROC-2", true)),
+          spec -> spec.recipe(new FindWord("PROC-2", true))
+              .dataTable(WordSearchResult.Row.class, rows ->
+                  assertThat(rows).hasSize(3)
+                      .extracting(WordSearchResult.Row::getMatchedWord)
+                      .containsOnly("PROC-2")),
           cobol(
             getNistResource("SM101A.CBL"),
             sm101A, spec -> spec.afterRecipe(cu -> {
@@ -115,7 +124,9 @@ class FindWordTest extends CobolTest {
     @Test
     void cm102mPartialMatch() {
         rewriteRun(
-          spec -> spec.recipe(new FindWord("cm.*", false)),
+          spec -> spec.recipe(new FindWord("cm.*", false))
+              .dataTable(WordSearchResult.Row.class, rows ->
+                  assertThat(rows).hasSize(39)),
           cobol(
             """
               000100 IDENTIFICATION DIVISION.                                         CM1024.2


### PR DESCRIPTION
## Summary

- Adds `WordSearchResult`, `ReferenceSearchResult`, and `IndicatorSearchResult` data table classes
- Wires data tables into `FindWord`, `FindReference`, and `FindIndicators` alongside existing `SearchResult.found()` markers
- Adds `dataTable()` test assertions to `FindWordTest` and `FindIndicatorsTest`

## Why

Search recipes that only use `SearchResult.found()` markers produce diffs but no structured output for the Moderne CLI console. The CLI renders search result summaries via data tables, which is why `FindCopybook` and `FindRelationships` (which already have data tables) show results in the console while `FindWord`, `FindReference`, and `FindIndicators` did not.

This aligns all COBOL search recipes with the established pattern from the core rewrite find recipes (`FindMethods`, `FindTypes`, `FindSourceFiles`), which all use both `SearchResult.found()` markers for diff output **and** data tables for structured CLI/platform output.