### PR TITLE
Recognize .dcl (DCLGEN) files as copybooks for EXEC SQL INCLUDE

### DIFF
--- a/src/main/java/org/openrewrite/cobol/Assertions.java
+++ b/src/main/java/org/openrewrite/cobol/Assertions.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 
@@ -255,7 +256,10 @@ public class Assertions {
 
     private static List<SourceFile> getCopybookSources() {
         try (ScanResult scan = new ClassGraph().scan()) {
-            List<Parser.Input> copyInputs = scan.getResourcesWithExtension("cpy").stream()
+            // .cpy copybooks and .dcl DCLGEN members are both resolvable via COPY / EXEC SQL INCLUDE.
+            List<Parser.Input> copyInputs = Stream.concat(
+                            scan.getResourcesWithExtension("cpy").stream(),
+                            scan.getResourcesWithExtension("dcl").stream())
                     .map(res -> new Parser.Input(Paths.get(res.getPath()), () -> {
                         try {
                             return new ByteArrayInputStream(res.getContentAsString().getBytes());

--- a/src/main/java/org/openrewrite/cobol/CobolParser.java
+++ b/src/main/java/org/openrewrite/cobol/CobolParser.java
@@ -38,6 +38,7 @@ import org.openrewrite.tree.ParsingExecutionContextView;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -48,7 +49,7 @@ import static java.util.stream.Collectors.toList;
 
 @RequiredArgsConstructor
 public class CobolParser implements Parser {
-    public static final List<String> COPYBOOK_FILE_EXTENSIONS = singletonList(".cpy");
+    public static final List<String> COPYBOOK_FILE_EXTENSIONS = Arrays.asList(".cpy", ".dcl");
     public static final List<String> COBOL_FILE_EXTENSIONS = singletonList(".cbl");
 
     private final CobolDialect cobolDialect;

--- a/src/main/java/org/openrewrite/cobol/CopybookParser.java
+++ b/src/main/java/org/openrewrite/cobol/CopybookParser.java
@@ -37,6 +37,7 @@ import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -49,7 +50,7 @@ import static org.openrewrite.Tree.randomId;
  */
 @RequiredArgsConstructor
 public class CopybookParser implements Parser {
-    public static final List<String> COPYBOOK_FILE_EXTENSIONS = singletonList(".cpy");
+    public static final List<String> COPYBOOK_FILE_EXTENSIONS = Arrays.asList(".cpy", ".dcl");
 
     private final CobolDialect cobolDialect;
 

--- a/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
+++ b/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
@@ -48,6 +48,35 @@ class CobolParserCopyTest extends CobolTest {
         );
     }
 
+    @Test
+    void execSqlIncludeDclgenMember() {
+        rewriteRun(
+          cobolPostProcess(
+            """
+              000000* Prevent trim
+                     IDENTIFICATION DIVISION.
+                     PROGRAM-ID. MGSECLDL.
+                     DATA DIVISION.
+                     WORKING-STORAGE SECTION.
+                     EXEC SQL INCLUDE MGSACATG END-EXEC.
+                     PROCEDURE DIVISION.
+                         STOP RUN.
+              """,
+            """
+              IDENTIFICATION DIVISION.
+              PROGRAM-ID. MGSECLDL.
+              DATA DIVISION.
+              WORKING-STORAGE SECTION.
+                  01  DCLSAMPLE-TABLE.
+                      10 COL-A              PIC X(3).
+                      10 COL-B              PIC X(30).
+              PROCEDURE DIVISION.
+                  STOP RUN.
+              """
+          )
+        );
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
       "COPY TRAILING_WHITESPACE.",

--- a/src/test/resources/gov/nist/copybooks/MGSACATG.dcl
+++ b/src/test/resources/gov/nist/copybooks/MGSACATG.dcl
@@ -1,0 +1,9 @@
+000000*    DCLGEN-generated DB2 host variable structure
+           EXEC SQL DECLARE SAMPLE_TABLE TABLE
+           ( COL_A                  CHAR(3) NOT NULL,
+             COL_B                  CHAR(30) NOT NULL
+           ) END-EXEC.
+      *    COBOL DECLARATION FOR TABLE SAMPLE_TABLE
+           01  DCLSAMPLE-TABLE.
+               10 COL-A              PIC X(3).
+               10 COL-B              PIC X(30).


### PR DESCRIPTION
## Problem

COBOL programs include DB2 host variable structures via `EXEC SQL INCLUDE <member>`. When those members are generated by DCLGEN and stored with a `.dcl` extension (instead of `.cpy`), they were **not recognized as copybooks**, so the includes were never expanded. This left missing data structures in the LST, an incomplete view of DB2-related logic, and reduced recipe accuracy.

## Root cause

The `EXEC SQL INCLUDE` machinery already works end-to-end: the grammar parses it into `ExecSqlIncludeStatement`, and `PreprocessCopyVisitor` resolves it against the copybook map exactly like a `COPY`, keyed by **filename without extension**. The only gap was that `.dcl` files were never *recognized* as copybooks, so they were never parsed/added to the lookup map — every such include fell through to `MissingCopybook`.

## Change

- Add `.dcl` to `COPYBOOK_FILE_EXTENSIONS` in `CopybookParser` and `CobolParser` (drives `accept()`). `.dcl` members are now parsed and resolved by member name through the existing COPY / `EXEC SQL INCLUDE` resolution — no keying or grammar changes needed.
- Extend the test harness copybook scan (`Assertions.getCopybookSources`) to discover both `.cpy` and `.dcl` resources.
- Add `CobolParserCopyTest.execSqlIncludeDclgenMember` plus a generic DCLGEN fixture, verifying that `EXEC SQL INCLUDE` of a `.dcl` member expands its host-variable structure into the post-processed LST.
