### PR TITLE
Expand external SYSIN/SYSTSIN .prm members into the JCL LST

### DIFF
--- a/src/main/java/org/openrewrite/jcl/ExpandExternalSysinVisitor.java
+++ b/src/main/java/org/openrewrite/jcl/ExpandExternalSysinVisitor.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jcl;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.SourceFile;
+import org.openrewrite.jcl.marker.GeneratedParmContent;
+import org.openrewrite.jcl.marker.ParmMember;
+import org.openrewrite.jcl.tree.Jcl;
+import org.openrewrite.jcl.tree.Space;
+import org.openrewrite.jcl.tree.Statement;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.text.PlainText;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.openrewrite.Tree.randomId;
+
+/**
+ * Resolves external SYSIN/SYSTSIN (and other input control) DD statements that reference a
+ * PDS member, e.g. {@code //SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR}, against a supplied
+ * set of {@code .prm} members, and grafts the resolved member content into the LST.
+ * <p>
+ * Expansion is resolution-driven: a DD qualifies when (1) its {@code DSN}/{@code DSNAME}
+ * references a specific {@code dataset(member)}, and (2) its {@code DISP} is an input
+ * disposition ({@code SHR} or {@code OLD}). The supplied member set is the authority on what
+ * is a control member — a qualifying DD is marked with {@link ParmMember}: when the member is
+ * supplied its content is grafted as {@link Jcl.DataDefinitionStream} nodes
+ * ({@link ParmMember.Status#EXPANDED}), otherwise it is marked {@link ParmMember.Status#MISSING}.
+ * Output DDs and whole-data-set references are never touched.
+ * <p>
+ * The grafted stream nodes are tagged with {@link GeneratedParmContent} so the
+ * {@code JclPrinter} skips them; the original DD statements are left untouched, so the source
+ * round-trips byte-for-byte while the LST gains the expanded member content.
+ */
+public class ExpandExternalSysinVisitor<P> extends JclIsoVisitor<P> {
+
+    private static final Pattern DSN_MEMBER = Pattern.compile("^(.+)\\(([^)]+)\\)$");
+
+    /**
+     * JCL operation keywords. Used to tell a continuation line ({@code //} followed by a
+     * parameter) from a new unnamed statement ({@code //} followed by an operation).
+     */
+    private static final Set<String> OPERATIONS = new HashSet<>(Arrays.asList("JOB", "JCLLIB", "CNTL",
+            "ENDCNTL", "DD", "EXEC", "EXPORT", "IF", "INCLUDE", "NOTIFY", "OUTPUT", "PEND", "PROC",
+            "SCHEDULE", "SET", "XMIT"));
+
+    private final Map<String, SourceFile> parmMembers = new HashMap<>();
+
+    public ExpandExternalSysinVisitor(List<SourceFile> parmMembers) {
+        parmMembers.forEach(it -> {
+            String fileName = it.getSourcePath().getFileName().toString();
+            int dot = fileName.indexOf('.');
+            String key = (dot < 0 ? fileName : fileName.substring(0, dot)).toUpperCase(Locale.ROOT);
+            this.parmMembers.putIfAbsent(key, it);
+        });
+    }
+
+    @Override
+    public Jcl.CompilationUnit visitCompilationUnit(Jcl.CompilationUnit cu, P p) {
+        List<Statement> in = cu.getStatements();
+        List<Statement> out = new ArrayList<>(in.size());
+        boolean changed = false;
+
+        int i = 0;
+        while (i < in.size()) {
+            DdGroup group = matchDdGroup(in, i);
+            if (group == null) {
+                out.add(in.get(i));
+                i++;
+                continue;
+            }
+
+            ParmMember marker = group.dsnIndex < 0 ? null : evaluate(group.ddName, group.params);
+            for (int k = group.start; k < group.end; k++) {
+                Statement s = in.get(k);
+                if (marker != null && k == group.dsnIndex) {
+                    Jcl.JclStatement js = (Jcl.JclStatement) s;
+                    s = js.withMarkers(js.getMarkers().addIfAbsent(marker));
+                    changed = true;
+                }
+                out.add(s);
+            }
+
+            if (marker != null && marker.getStatus() == ParmMember.Status.EXPANDED) {
+                String memberName = marker.getMemberName();
+                List<Statement> grafted = buildStreamNodes(
+                        parmMembers.get(memberName.toUpperCase(Locale.ROOT)), memberName);
+                out.addAll(grafted);
+                changed |= !grafted.isEmpty();
+            }
+            i = group.end;
+        }
+
+        return changed ? cu.withStatements(out) : cu;
+    }
+
+    /**
+     * Matches a logical DD statement starting at {@code start}: a name/blank field
+     * ({@code //NAME} or bare {@code //}) followed by the {@code DD} operation and its
+     * parameter words, walking across {@code //}-continuation lines. Returns {@code null}
+     * when no DD statement starts at {@code start}.
+     */
+    private @Nullable DdGroup matchDdGroup(List<Statement> statements, int start) {
+        Statement head = statements.get(start);
+        if (!(head instanceof Jcl.JclStatement)) {
+            return null;
+        }
+        String headText = text(head);
+        if (!headText.startsWith("//") || isComment(headText)) {
+            return null;
+        }
+        if (start + 1 >= statements.size() || !isWord(statements.get(start + 1), "DD")) {
+            return null;
+        }
+
+        String ddName = headText.length() > 2 ? headText.substring(2) : "";
+        StringBuilder params = new StringBuilder();
+        int dsnIndex = -1;
+        // The operand field is a single blank-free token per line segment; the first word
+        // after the operation (or after a //-continuation) is the operand, and any further
+        // words on that line are the comment field, which is ignored.
+        boolean expectOperand = true;
+        int j = start + 2;
+        for (; j < statements.size(); j++) {
+            Statement s = statements.get(j);
+            if (!(s instanceof Jcl.JclStatement)) {
+                break;
+            }
+            String t = text(s);
+            if (t.startsWith("//")) {
+                boolean continuation = t.equals("//") &&
+                        j + 1 < statements.size() && !isOperation(statements.get(j + 1));
+                if (continuation) {
+                    expectOperand = true; // operands resume after the continuation marker
+                    continue;
+                }
+                break; // a new statement begins
+            }
+            if (expectOperand) {
+                params.append(t);
+                if (dsnIndex < 0 && isDsnAssignment(t)) {
+                    dsnIndex = j;
+                }
+                expectOperand = false;
+            }
+        }
+        return new DdGroup(start, j, dsnIndex, ddName, params.toString());
+    }
+
+    /**
+     * Returns the marker for a qualifying input DD that references a specific member, or
+     * {@code null} when the DD does not qualify for expansion.
+     */
+    private @Nullable ParmMember evaluate(String ddName, String params) {
+        String dsn = null;
+        String disp = null;
+        for (String param : splitParams(params)) {
+            String upper = param.toUpperCase(Locale.ROOT);
+            if (dsn == null && (upper.startsWith("DSN=") || upper.startsWith("DSNAME="))) {
+                dsn = param.substring(param.indexOf('=') + 1);
+            } else if (disp == null && upper.startsWith("DISP=")) {
+                disp = param.substring(param.indexOf('=') + 1);
+            }
+        }
+        if (dsn == null || !isInputDisposition(disp)) {
+            return null;
+        }
+        Matcher m = DSN_MEMBER.matcher(dsn);
+        if (!m.matches()) {
+            return null; // whole-data-set reference, no specific member to resolve
+        }
+        String dataSetName = m.group(1);
+        String memberName = m.group(2);
+        if (memberName.indexOf('&') >= 0 || memberName.indexOf('%') >= 0) {
+            // Unresolved symbolic member reference; left for symbolic substitution, not expanded.
+            return null;
+        }
+        ParmMember.Status status = parmMembers.containsKey(memberName.toUpperCase(Locale.ROOT)) ?
+                ParmMember.Status.EXPANDED : ParmMember.Status.MISSING;
+        return new ParmMember(randomId(), status, ddName, dataSetName, memberName);
+    }
+
+    /**
+     * Tokenizes the resolved member content into {@link Jcl.DataDefinitionStream} nodes —
+     * one per whitespace-delimited word, matching how an inline {@code DD *} stream is
+     * represented — each tagged with {@link GeneratedParmContent}.
+     * <p>
+     * Only columns 1–72 of each line are tokenized; the identification/sequence-number area
+     * in columns 73–80 of fixed-form PDS members is ignored, consistent with how the JCL
+     * line reader treats columns beyond 72.
+     */
+    private static List<Statement> buildStreamNodes(@Nullable SourceFile member, String memberName) {
+        List<Statement> nodes = new ArrayList<>();
+        if (!(member instanceof PlainText)) {
+            return nodes;
+        }
+        String[] lines = ((PlainText) member).getText().split("\n", -1);
+        for (int li = 0; li < lines.length; li++) {
+            String line = lines[li];
+            if (line.endsWith("\r")) {
+                line = line.substring(0, line.length() - 1);
+            }
+            if (line.length() > 72) {
+                line = line.substring(0, 72);
+            }
+            boolean firstOnLine = true;
+            int idx = 0;
+            while (idx < line.length()) {
+                int wsStart = idx;
+                while (idx < line.length() && Character.isWhitespace(line.charAt(idx))) {
+                    idx++;
+                }
+                String ws = line.substring(wsStart, idx);
+                if (idx >= line.length()) {
+                    break;
+                }
+                int textStart = idx;
+                while (idx < line.length() && !Character.isWhitespace(line.charAt(idx))) {
+                    idx++;
+                }
+                String prefix = (li > 0 && firstOnLine ? "\n" : "") + ws;
+                nodes.add(new Jcl.DataDefinitionStream(
+                        randomId(),
+                        Space.build(prefix),
+                        Markers.EMPTY.addIfAbsent(new GeneratedParmContent(randomId(), memberName)),
+                        new Jcl.Word(randomId(), Space.EMPTY, Markers.EMPTY, line.substring(textStart, idx))));
+                firstOnLine = false;
+            }
+        }
+        return nodes;
+    }
+
+    /**
+     * Splits a JCL parameter string on commas at parenthesis depth zero, so that commas
+     * inside sub-parameter lists such as {@code DISP=(NEW,CATLG,DELETE)} do not split.
+     */
+    private static List<String> splitParams(String params) {
+        List<String> result = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < params.length(); i++) {
+            char c = params.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+            } else if (c == ',' && depth == 0) {
+                result.add(params.substring(start, i));
+                start = i + 1;
+            }
+        }
+        result.add(params.substring(start));
+        return result;
+    }
+
+    private static boolean isInputDisposition(@Nullable String disp) {
+        if (disp == null) {
+            return false;
+        }
+        // Reduce to the status (first positional) sub-parameter, e.g. DISP=(SHR,KEEP) -> SHR.
+        String status = disp.trim();
+        if (status.startsWith("(")) {
+            status = status.substring(1);
+        }
+        int end = status.length();
+        for (int i = 0; i < status.length(); i++) {
+            char c = status.charAt(i);
+            if (c == ',' || c == ')') {
+                end = i;
+                break;
+            }
+        }
+        status = status.substring(0, end).trim().toUpperCase(Locale.ROOT);
+        return "SHR".equals(status) || "OLD".equals(status);
+    }
+
+    private static boolean isDsnAssignment(String text) {
+        String upper = text.toUpperCase(Locale.ROOT);
+        return upper.startsWith("DSN=") || upper.startsWith("DSNAME=");
+    }
+
+    private static boolean isComment(String headText) {
+        return headText.length() > 2 && headText.charAt(2) == '*';
+    }
+
+    private static boolean isOperation(Statement statement) {
+        return statement instanceof Jcl.JclStatement &&
+                OPERATIONS.contains(text(statement).toUpperCase(Locale.ROOT));
+    }
+
+    private static boolean isWord(Statement statement, String word) {
+        return statement instanceof Jcl.JclStatement && text(statement).equalsIgnoreCase(word);
+    }
+
+    private static String text(Statement statement) {
+        return ((Jcl.JclStatement) statement).getWord().getText();
+    }
+
+    /**
+     * The span of a logical DD statement within the flat statement list.
+     */
+    private static final class DdGroup {
+        final int start;
+        final int end;
+        final int dsnIndex;
+        final String ddName;
+        final String params;
+
+        DdGroup(int start, int end, int dsnIndex, String ddName, String params) {
+            this.start = start;
+            this.end = end;
+            this.dsnIndex = dsnIndex;
+            this.ddName = ddName;
+            this.params = params;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/jcl/JclParser.java
+++ b/src/main/java/org/openrewrite/jcl/JclParser.java
@@ -18,6 +18,7 @@ package org.openrewrite.jcl;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.*;
 import org.jspecify.annotations.Nullable;
@@ -35,9 +36,19 @@ import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
+
+@AllArgsConstructor
 public class JclParser implements Parser {
+
+    /**
+     * External PDS members (e.g. {@code .prm} files) referenced by SYSIN/SYSTSIN and other
+     * input control DD statements, supplied out-of-band and resolved by member name.
+     */
+    private final List<SourceFile> parmMembers;
 
     @Override
     public Stream<SourceFile> parseInputs(Iterable<Input> sourceFiles, @Nullable Path relativeTo, ExecutionContext ctx) {
@@ -69,6 +80,11 @@ public class JclParser implements Parser {
                                 is.getCharset(),
                                 is.isCharsetBomMarked()
                         ).visitCompilationUnit(parser.compilationUnit());
+
+                        if (!parmMembers.isEmpty()) {
+                            cu = new ExpandExternalSysinVisitor<ExecutionContext>(parmMembers)
+                                    .visitCompilationUnit(cu, ctx);
+                        }
 
                         sample.stop(MetricsHelper.successTags(timer).register(Metrics.globalRegistry));
                         parsingListener.parsed(sourceFile, cu);
@@ -109,13 +125,20 @@ public class JclParser implements Parser {
     }
 
     public static class Builder extends org.openrewrite.Parser.Builder {
+        private List<SourceFile> parmMembers = emptyList();
+
         public Builder() {
             super(Jcl.CompilationUnit.class);
         }
 
+        public Builder parmMembers(List<SourceFile> parmMembers) {
+            this.parmMembers = parmMembers;
+            return this;
+        }
+
         @Override
         public JclParser build() {
-            return new JclParser();
+            return new JclParser(parmMembers);
         }
 
         @Override

--- a/src/main/java/org/openrewrite/jcl/internal/JclPrinter.java
+++ b/src/main/java/org/openrewrite/jcl/internal/JclPrinter.java
@@ -20,6 +20,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.jcl.JclVisitor;
 import org.openrewrite.jcl.marker.CommentArea;
+import org.openrewrite.jcl.marker.GeneratedParmContent;
 import org.openrewrite.jcl.marker.TrailingComment;
 import org.openrewrite.jcl.tree.Jcl;
 import org.openrewrite.jcl.tree.Space;
@@ -59,6 +60,10 @@ public class JclPrinter<P> extends JclVisitor<PrintOutputCapture<P>> {
 
     @Override
     public Jcl visitDataDefinitionStream(Jcl.DataDefinitionStream ddStream, PrintOutputCapture<P> p) {
+        if (ddStream.getMarkers().findFirst(GeneratedParmContent.class).isPresent()) {
+            // Content grafted from an external PDS member; not part of the original source.
+            return ddStream;
+        }
         beforeSyntax(ddStream, Space.Location.DATA_DEFINITION_STREAM_PREFIX, p);
         visit(ddStream.getWord(), p);
         afterSyntax(ddStream, p);

--- a/src/main/java/org/openrewrite/jcl/marker/GeneratedParmContent.java
+++ b/src/main/java/org/openrewrite/jcl/marker/GeneratedParmContent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jcl.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a {@code DataDefinitionStream} node that was grafted into the LST from an external
+ * PDS member (see {@link ParmMember}), rather than read from the original source. The
+ * {@code JclPrinter} skips nodes carrying this marker so the source still round-trips
+ * byte-for-byte.
+ */
+@With
+@Value
+public class GeneratedParmContent implements Marker {
+    UUID id;
+
+    /**
+     * The member the content was expanded from (e.g. {@code MGSLAP8F}).
+     */
+    String memberName;
+}

--- a/src/main/java/org/openrewrite/jcl/marker/ParmMember.java
+++ b/src/main/java/org/openrewrite/jcl/marker/ParmMember.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jcl.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a DD statement that references an external PDS member, e.g.
+ * {@code //SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR}. When {@link Status#EXPANDED}, the
+ * member was resolved against the supplied set of {@code .prm} members and its content
+ * grafted into the LST as {@link org.openrewrite.jcl.tree.Jcl.DataDefinitionStream} nodes;
+ * when {@link Status#MISSING}, the DD qualified for expansion but the member was not
+ * supplied. Either way the original DD statement is left untouched, so the source still
+ * round-trips byte-for-byte.
+ */
+@With
+@Value
+public class ParmMember implements Marker {
+    UUID id;
+
+    Status status;
+
+    /**
+     * The DD name (e.g. {@code SYSIN}, {@code SYSTSIN}), or empty for an unnamed DD.
+     */
+    String ddName;
+
+    /**
+     * The referenced data set name, ignored for member resolution but retained for
+     * diagnostics (e.g. {@code DWL.PARMLIB}).
+     */
+    String dataSetName;
+
+    /**
+     * The member name used for resolution (e.g. {@code MGSLAP8F}).
+     */
+    String memberName;
+
+    public enum Status {
+        /** The member was resolved and its content grafted into the LST. */
+        EXPANDED,
+        /** The DD qualified for expansion but the member was not supplied. */
+        MISSING
+    }
+}

--- a/src/test/java/org/openrewrite/jcl/tree/ExternalSysinTest.java
+++ b/src/test/java/org/openrewrite/jcl/tree/ExternalSysinTest.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jcl.tree;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.SourceFile;
+import org.openrewrite.jcl.marker.GeneratedParmContent;
+import org.openrewrite.jcl.marker.ParmMember;
+import org.openrewrite.jcl.tree.Jcl.DataDefinitionStream;
+import org.openrewrite.jcl.tree.Jcl.JclStatement;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.jcl.tree.ParserAssertions.jcl;
+import static org.openrewrite.jcl.tree.ParserAssertions.parmMember;
+
+class ExternalSysinTest implements RewriteTest {
+
+    private static final List<SourceFile> SORT_MEMBER = singletonList(parmMember("MGSLAP8F",
+            """
+              SORT FIELDS=(8,2,PD,A,10,4,PD,A,14,2,PD,A,16,1,CH,A)
+              """));
+
+    private static Optional<ParmMember> parmMarker(Jcl.CompilationUnit cu) {
+        return cu.getStatements().stream()
+                .flatMap(s -> s.getMarkers().getMarkers().stream())
+                .filter(ParmMember.class::isInstance)
+                .map(ParmMember.class::cast)
+                .findFirst();
+    }
+
+    private static Optional<ParmMember> parmMarker(Jcl.CompilationUnit cu, ParmMember.Status status) {
+        return parmMarker(cu).filter(m -> m.getStatus() == status);
+    }
+
+    private static List<String> graftedWords(Jcl.CompilationUnit cu) {
+        return cu.getStatements().stream()
+                .filter(s -> s instanceof DataDefinitionStream)
+                .filter(s -> s.getMarkers().findFirst(GeneratedParmContent.class).isPresent())
+                .map(s -> ((DataDefinitionStream) s).getWord().getText())
+                .collect(toList());
+    }
+
+    private static String wordText(Statement s) {
+        if (s instanceof JclStatement) {
+            return ((JclStatement) s).getWord().getText();
+        }
+        if (s instanceof DataDefinitionStream) {
+            return ((DataDefinitionStream) s).getWord().getText();
+        }
+        return "";
+    }
+
+    @Test
+    void resolvesExternalSysinMember() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> {
+                Optional<ParmMember> marker = parmMarker(cu, ParmMember.Status.EXPANDED);
+                assertThat(marker).isPresent();
+                assertThat(marker.get().getDdName()).isEqualTo("SYSIN");
+                assertThat(marker.get().getDataSetName()).isEqualTo("DWL.PARMLIB");
+                assertThat(marker.get().getMemberName()).isEqualTo("MGSLAP8F");
+            })
+          )
+        );
+    }
+
+    @Test
+    void resolvesSystsinMember() {
+        rewriteRun(
+          jcl(
+            "//SYSTSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu ->
+                assertThat(parmMarker(cu, ParmMember.Status.EXPANDED)).isPresent())
+          )
+        );
+    }
+
+    @Test
+    void caseInsensitiveMemberLookup() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=dwl.parmlib(mgslap8f),disp=shr",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu ->
+                assertThat(parmMarker(cu, ParmMember.Status.EXPANDED)).isPresent())
+          )
+        );
+    }
+
+    @Test
+    void graftsResolvedMemberContentAsStreamNodes() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> assertThat(graftedWords(cu)).containsExactly(
+                "SORT",
+                "FIELDS=(8,2,PD,A,10,4,PD,A,14,2,PD,A,16,1,CH,A)"))
+          )
+        );
+    }
+
+    @Test
+    void graftedContentDoesNotAffectRoundTrip() {
+        // The before == after (implicit) assertion verifies the grafted DataDefinitionStream
+        // nodes are not re-printed, so the source is reproduced byte-for-byte.
+        rewriteRun(
+          jcl(
+            """
+              //STEP1   EXEC PGM=SORT
+              //SYSIN    DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR
+              //SYSOUT   DD SYSOUT=*
+              """,
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> assertThat(graftedWords(cu)).isNotEmpty())
+          )
+        );
+    }
+
+    @Test
+    void missingMemberGraftsNothing() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(NOTHERE),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> assertThat(graftedWords(cu)).isEmpty())
+          )
+        );
+    }
+
+    @Test
+    void marksMissingMemberWhenNotSupplied() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(NOTHERE),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> {
+                Optional<ParmMember> marker = parmMarker(cu, ParmMember.Status.MISSING);
+                assertThat(marker).isPresent();
+                assertThat(marker.get().getMemberName()).isEqualTo("NOTHERE");
+            })
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"OLD", "(SHR)", "(OLD,KEEP)", "(SHR,KEEP,KEEP)"})
+    void expandsInputDispositions(String disp) {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=" + disp,
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu ->
+                assertThat(parmMarker(cu, ParmMember.Status.EXPANDED)).isPresent())
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"MOD", "(NEW,CATLG,DELETE)", "(MOD,KEEP)", "(,DELETE)"})
+    void doesNotExpandNonInputDispositions(String disp) {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=" + disp,
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> assertThat(parmMarker(cu)).isEmpty())
+          )
+        );
+    }
+
+    @Test
+    void doesNotExpandWhenDispositionAbsent() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F)",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> assertThat(parmMarker(cu)).isEmpty())
+          )
+        );
+    }
+
+    @Test
+    void expandsNonSysinControlDd() {
+        // Expansion is resolution-driven, not gated on the DD name: any input DD whose
+        // member is supplied is expanded.
+        rewriteRun(
+          jcl(
+            "//PARMIN DD DSN=DWL.CNTL(MGSLAP8F),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> {
+                Optional<ParmMember> marker = parmMarker(cu, ParmMember.Status.EXPANDED);
+                assertThat(marker).isPresent();
+                assertThat(marker.get().getDdName()).isEqualTo("PARMIN");
+                assertThat(graftedWords(cu)).isNotEmpty();
+            })
+          )
+        );
+    }
+
+    @Test
+    void resolvesDsnameLongForm() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSNAME=DWL.PARMLIB(MGSLAP8F),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu ->
+                assertThat(parmMarker(cu, ParmMember.Status.EXPANDED)).isPresent())
+          )
+        );
+    }
+
+    @Test
+    void graftsMultiLineMemberContent() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(MULTI),DISP=SHR",
+            singletonList(parmMember("MULTI",
+              """
+                SORT FIELDS=(1,4,CH,A)
+                MERGE FIELDS=(5,2,CH,D)
+                """)),
+            spec -> spec.afterRecipe(cu ->
+                assertThat(graftedWords(cu)).containsExactly(
+                    "SORT", "FIELDS=(1,4,CH,A)",
+                    "MERGE", "FIELDS=(5,2,CH,D)"))
+          )
+        );
+    }
+
+    @Test
+    void graftedNodesFollowReferencingDd() {
+        rewriteRun(
+          jcl(
+            """
+              //STEP1   EXEC PGM=SORT
+              //SYSIN    DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR
+              //SYSOUT   DD SYSOUT=*
+              """,
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> {
+                List<String> texts = cu.getStatements().stream()
+                        .map(ExternalSysinTest::wordText)
+                        .collect(toList());
+                int dsn = texts.indexOf("DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR");
+                int sort = texts.indexOf("SORT");
+                int sysout = texts.indexOf("//SYSOUT");
+                assertThat(sort).isGreaterThan(dsn).isLessThan(sysout);
+            })
+          )
+        );
+    }
+
+    @Test
+    void resolvesAcrossContinuation() {
+        rewriteRun(
+          jcl(
+            """
+              //SYSIN    DD DSN=DWL.PARMLIB(MGSLAP8F),
+              //            DISP=SHR
+              """,
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu ->
+                assertThat(parmMarker(cu, ParmMember.Status.EXPANDED)).isPresent())
+          )
+        );
+    }
+
+    @Test
+    void skipsSymbolicMemberReference() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(&MBR),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu -> {
+                assertThat(parmMarker(cu)).isEmpty();
+                assertThat(graftedWords(cu)).isEmpty();
+            })
+          )
+        );
+    }
+
+    @Test
+    void resolvesConcreteMemberWithSymbolicDataSet() {
+        // The data set qualifier is ignored for lookup, so a symbolic qualifier with a
+        // concrete member still resolves.
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=&HLQ..PARMLIB(MGSLAP8F),DISP=SHR",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu ->
+                assertThat(parmMarker(cu, ParmMember.Status.EXPANDED)).isPresent())
+          )
+        );
+    }
+
+    @Test
+    void concatenatedDdsEachExpand() {
+        List<SourceFile> members = List.of(
+          parmMember("MGSLAP8F", "SORT FIELDS=(1,2,CH,A)\n"),
+          parmMember("MGSLAP9G", "MERGE FIELDS=(3,4,CH,A)\n"));
+        rewriteRun(
+          jcl(
+            """
+              //SYSIN    DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR
+              //         DD DSN=DWL.PARMLIB(MGSLAP9G),DISP=SHR
+              """,
+            members,
+            spec -> spec.afterRecipe(cu ->
+                assertThat(graftedWords(cu)).containsExactly(
+                    "SORT", "FIELDS=(1,2,CH,A)",
+                    "MERGE", "FIELDS=(3,4,CH,A)"))
+          )
+        );
+    }
+
+    @Test
+    void ignoresSequenceNumberArea() {
+        // Columns 73-80 carry sequence numbers in fixed-form PDS members and must not
+        // become part of the grafted stream content.
+        String statement = "SORT FIELDS=(1,2,CH,A)";
+        String numbered = statement + " ".repeat(72 - statement.length()) + "00010000\n";
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(NUMBERED),DISP=SHR",
+            singletonList(parmMember("NUMBERED", numbered)),
+            spec -> spec.afterRecipe(cu ->
+                assertThat(graftedWords(cu)).containsExactly("SORT", "FIELDS=(1,2,CH,A)"))
+          )
+        );
+    }
+
+    @Test
+    void keepsSymbolicsInGraftedContentLiteral() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(REPLMBR),DISP=SHR",
+            singletonList(parmMember("REPLMBR", "REPL DBN=%%NAME.FIELD,SEG=&SEGNAME\n")),
+            spec -> spec.afterRecipe(cu ->
+                assertThat(graftedWords(cu)).containsExactly(
+                    "REPL", "DBN=%%NAME.FIELD,SEG=&SEGNAME"))
+          )
+        );
+    }
+
+    @Test
+    void graftsCrlfMemberContent() {
+        String content = "SORT FIELDS=(1,4,CH,A)\r\nMERGE FIELDS=(5,2,CH,D)\r\n";
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(CRLFMBR),DISP=SHR",
+            singletonList(parmMember("CRLFMBR", content)),
+            spec -> spec.afterRecipe(cu ->
+                assertThat(graftedWords(cu)).containsExactly(
+                    "SORT", "FIELDS=(1,4,CH,A)",
+                    "MERGE", "FIELDS=(5,2,CH,D)"))
+          )
+        );
+    }
+
+    @Test
+    void expandsWithTrailingCommentOnDd() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR  *trailing comment                 commentArea\n",
+            SORT_MEMBER,
+            spec -> spec.afterRecipe(cu ->
+                assertThat(parmMarker(cu, ParmMember.Status.EXPANDED)).isPresent())
+          )
+        );
+    }
+
+    @Test
+    void noMarkersWhenNoMembersSupplied() {
+        rewriteRun(
+          jcl(
+            "//SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR",
+            spec -> spec.afterRecipe(cu -> assertThat(parmMarker(cu)).isEmpty())
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/jcl/tree/ParserAssertions.java
+++ b/src/test/java/org/openrewrite/jcl/tree/ParserAssertions.java
@@ -19,19 +19,46 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
 import org.openrewrite.jcl.JclIsoVisitor;
 import org.openrewrite.jcl.JclParser;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
+import org.openrewrite.text.PlainText;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.function.Consumer;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.Tree.randomId;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ParserAssertions {
 
     static void customizeExecutionContext(ExecutionContext ctx) {
+    }
+
+    /**
+     * Builds an external PDS member source (e.g. a {@code .prm} member) keyed by member name,
+     * for resolution by {@link org.openrewrite.jcl.ExpandExternalSysinVisitor}.
+     */
+    public static SourceFile parmMember(String memberName, String content) {
+        return new PlainText(randomId(), Paths.get(memberName + ".prm"), Markers.EMPTY,
+                StandardCharsets.UTF_8.name(), false, null, null, content, emptyList());
+    }
+
+    public static SourceSpecs jcl(@Nullable String before, List<SourceFile> parmMembers,
+                                  Consumer<SourceSpec<Jcl.CompilationUnit>> spec) {
+        SourceSpec<Jcl.CompilationUnit> jcl = new SourceSpec<>(
+                Jcl.CompilationUnit.class, null, JclParser.builder().parmMembers(parmMembers), before,
+                SourceSpec.ValidateSource.noop,
+                ParserAssertions::customizeExecutionContext);
+        acceptSpec(spec, jcl);
+        return jcl;
     }
 
     public static SourceSpecs jcl(@Nullable String before) {


### PR DESCRIPTION
## What

Expands external SYSIN/SYSTSIN (and other input control) DD members referenced via `DSN=dataset(member)` into the JCL LST, analogous to COBOL `COPY` expansion.

Given a DD such as `//SYSIN DD DSN=DWL.PARMLIB(MGSLAP8F),DISP=SHR`, the resolved member content is grafted into the LST as `DataDefinitionStream` nodes appended after the DD. The original DD line is left untouched, so the source still round-trips byte-for-byte.

### How it works
- `JclParser.builder().parmMembers(List<SourceFile>)` supplies members out-of-band, keyed by **member name only** (dataset qualifier ignored), `<MEMBER>.prm`, case-insensitive — mirroring how copybooks are supplied.
- `ExpandExternalSysinVisitor` runs post-parse (only when members are supplied) and:
  - reconstructs logical DD statements from word-level `JclStatement`s, including `//` continuation lines and the operand-vs-comment field split;
  - gates resolution-driven (not a DD-name list): a specific `DSN`/`DSNAME` `(member)`, input disposition (`DISP=SHR`/`OLD`), non-symbolic member name;
  - grafts member content as `DataDefinitionStream` nodes (one per word, honoring the 72-column rule); each carries `GeneratedParmContent` so `JclPrinter` skips it on output.
- A `ParmMember` marker records each reference as `EXPANDED` or `MISSING`.

## Required follow-up in the CLI (moderne-cli)

This library change is **inert until the CLI supplies the members** — today `MainframeBuildStep` builds `JclParser.builder().build()` with none, so nothing is expanded in real builds. To activate it, the CLI's `MainframeBuildStep` needs:

- **Discover `.prm` files** under the repo root (respecting the existing file-inclusion rules).
- **Parse them as `PlainText`** sources, named so the member name is the lookup key.
- **Pass them to the JCL parser** via the new `JclParser.builder().parmMembers(...)` seam.
- **Collect members before parsing JCL** (a two-phase step), since the `OmniParser` otherwise streams file-by-file.
- **Bump the `rewrite-cobol` dependency** to the release that includes `parmMembers(...)` (the CLI pins `latest.release`, so it picks up automatically once released).

Notes for the CLI change:
- `.prm` members are consumed only as members; they are **not** emitted as their own LSTs and are not handed to the parser as primary sources.
- This intentionally diverges from how the CLI handles copybooks today (it does **not** inject `.cpy` into `CobolParser`; copybooks ride as standalone LSTs). Worth a conscious decision during CLI review.
- Surfacing these references in the platform relationship graph (`FindRelationships`/`CobolRelationships`) is a separate, optional follow-up that would need a new resource type for parm members.
